### PR TITLE
Cleanup

### DIFF
--- a/bfgen.py
+++ b/bfgen.py
@@ -22,28 +22,7 @@ except:
 repl = {"@VERSION@": version,
         "@MONTHYEAR@": datetime.datetime.now().strftime("%b %Y")}
 
-# (venv)jmoore@necromancer /var/www/cvs.openmicroscopy.org.uk/snapshots/bioformats/4.4.4 $ openssl md5 *
-MD5s = """
-MD5(bftools.zip)= ff6a326bff7c687a3ae5124e5088ce06
-MD5(bio-formats.jar)= dffc404bee2ab699a642bf64ae6b1647
-MD5(jai_imageio.jar)= df61b168faa6f4b017b74d6f77cc0b6a
-MD5(loci-common.jar)= 4999039c4ab6894ad4baa5483212dedd
-MD5(loci-testing-framework.jar)= 0b93694decdd0e3ad88e8aa63b923fd0
-MD5(loci_plugins.jar)= 1abdb91e1529edf9912ab6118fe43284
-MD5(loci_tools.jar)= c1be9cb77ef9ef8c35c31a7d4b67d355
-MD5(lwf-stubs.jar)= 7dd5751b575a814489e24f4d3a1df230
-MD5(mdbtools-java.jar)= 487b162b5b4a0c121e3973eecc887cad
-MD5(metakit.jar)= 0610a135cb5476fe3830e5c8567a6c58
-MD5(ome-editor.jar)= e21ad42f4e4ba9902ca88ef2e1fb5e10
-MD5(ome-io.jar)= 16fc245bef5e451ee9861504f155f42b
-MD5(ome-xml.jar)= 28168ab9580bf9a24ed6a9ec02468b1c
-MD5(ome_plugins.jar)= ae20831ad75c8fb7105be40190eb8545
-MD5(ome_tools.jar)= 39da236aa47e6f3447e01dac7f9af43e
-MD5(poi-loci.jar)= 90372e92977db2a8d50c43e6ef0bb39e
-MD5(scifio.jar)= f25a2e7ac7af8c5513daa0f03ac74dc2
-"""
-MD5s = [x.split(" ")[1] for x in MD5s.split("\n") if x.strip()]
-
+MD5s = []
 
 # Creating Github instance
 try:

--- a/gen.py
+++ b/gen.py
@@ -19,12 +19,7 @@ from doc_generator import *
 
 
 fingerprint_url = "http://hudson.openmicroscopy.org.uk/fingerprint"
-MD5s = """
-MD5(4.4.5/OMERO-4.4.5.pdf)= d92d4bd40e2defb328756780c77a633e
-MD5(4.4.6/OMERO-4.4.6.pdf)= 03aace065d939bb7a47a13b47cf4cc70
-"""
-MD5s = [x.split(" ")[1] for x in MD5s.split("\n") if x.strip()]
-
+MD5s = []
 
 
 def usage():
@@ -59,6 +54,7 @@ if "STAGING" in os.environ:
     repl["@DOC_URL@"] = "https://www.openmicroscopy.org/site/support/omero4-staging"
 else:
     repl["@DOC_URL@"] = "https://www.openmicroscopy.org/site/support/omero4"
+repl["@PDF_URL@"] = repl["@DOC_URL@"] + "/OMERO-%s.pdf" % version
 
 if "SNAPSHOT_PATH" in os.environ:
     SNAPSHOT_PATH =  os.environ.get('SNAPSHOT_PATH')

--- a/tmpl.txt
+++ b/tmpl.txt
@@ -17,7 +17,7 @@ major release of OMERO. Refer to the following sections for more information
 about each release.
 
  * After downloading the relevant files, you may want to take a look at our OMERO @VERSION@ [online documentation](@DOC_URL@) page or
-[PDF documentation](@DOC@).
+[PDF documentation](@PDF_URL@).
 
 ## OMERO client @VERSION@ downloads ##
 


### PR DESCRIPTION
- Clean obsolete MD5s for previous versions
- Add PDF_URL for OMERO documentation linking to the one deployed live rather than the artefacts
