### PR TITLE
Add user_agent during Github construction

### DIFF
--- a/bfgen.py
+++ b/bfgen.py
@@ -55,7 +55,7 @@ try:
 except Exception:
     token = None
 
-gh = github.Github(token)
+gh = github.Github(token, user_agent="PyGithub")
 org = gh.get_organization("openmicroscopy")
 repo = org.get_repo("openmicroscopy")
 for tag in repo.get_tags():

--- a/gen.py
+++ b/gen.py
@@ -47,7 +47,7 @@ repl = {"@VERSION@": version,
         "@MONTHYEAR@": datetime.datetime.now().strftime("%b %Y")}
 
 
-gh = github.Github()
+gh = github.Github(user_agent="PyGithub")
 org = gh.get_organization("openmicroscopy")
 repo = org.get_repo("openmicroscopy")
 for tag in repo.get_tags():


### PR DESCRIPTION
As of today User Agent headers are mandatory for all Github API requests.
