### PR TITLE
Allow to pass milestone by environment variable

### DIFF
--- a/gen.py
+++ b/gen.py
@@ -75,6 +75,11 @@ if "ANNOUCEMENT_URL" in os.environ:
 else:
     repl["@ANNOUCEMENT_URL@"] = "https://www.openmicroscopy.org/community/viewforum.php?f=11"
 
+if "MILESTONE" in os.environ:
+    repl["@MILESTONE@"] = os.environ.get('MILESTONE')
+else:
+    repl["@MILESTONE@"] = "OMERO-%s" % version
+
 for x, y in (
     ("LINUX_CLIENTS", "@VERSION@/OMERO.clients-@VERSION@-ice33-@BUILD@.linux.zip"),
     ("MAC_CLIENTS", "@VERSION@/OMERO.clients-@VERSION@-ice33-@BUILD@.mac.zip"),

--- a/tmpl.txt
+++ b/tmpl.txt
@@ -118,7 +118,7 @@ Windows](@DOC_URL@/sysadmins/windows/server-installation.html) or using the
 Full details of features and what is new can be found in the 
 [announcement](@ANNOUCEMENT_URL@).
 
-Full milestone release notes can be found on the [OMERO Trac site](http://trac.openmicroscopy.org.uk/ome/milestone/OMERO-@VERSION@)
+Full milestone release notes can be found on the [OMERO Trac site](http://trac.openmicroscopy.org.uk/ome/milestone/@MILESTONE@)
 
 This release includes:
 


### PR DESCRIPTION
This commit is cherry-picked from gh-15 and allows to pass a milestone by environment variable instead of relying on the input version number
