### PR TITLE
Remove the hard-coded version number from the PDF documentation link

### DIFF
--- a/bfgen.py
+++ b/bfgen.py
@@ -49,7 +49,6 @@ repl["@SHA1_SHORT@"] = tag.commit.sha[0:10]
 repl["@DOC_URL@"] = "https://www.openmicroscopy.org/site/support/bio-formats%s" % major_version
 if "STAGING" in os.environ and os.environ.get("STAGING"):
     repl["@DOC_URL@"] += "-staging"
-repl["@PDF_URL@"] = repl["@DOC_URL@"] + "/Bio-Formats-%s.pdf" % version
 
 if "SNAPSHOT_PATH" in os.environ:
     SNAPSHOT_PATH =  os.environ.get('SNAPSHOT_PATH')

--- a/bftmpl.txt
+++ b/bftmpl.txt
@@ -9,7 +9,7 @@ Please note:
 * Internet Explorer sometimes renames JAR files to ZIP (e.g., loci_tools.jar becomes loci_tools.zip); if this happens to you, simply rename the file back to its original name after the download is complete.
 * For some browsers, you may need to right-click or control-click the link and choose "Save link as..." or a similar option to download the file.
 
-After downloading the relevant files, you may want to take a look at our Bio-Formats @VERSION@ [online documentation](@DOC_URL@) page or at the [PDF documentation](@PDF_URL@).
+After downloading the relevant files, you may want to take a look at our Bio-Formats @VERSION@ [online documentation](@DOC_URL@) page or at the [PDF documentation](/latest/bio-formats-manual-pdf).
 
 
 ## Bio-Formats trunk/daily builds ##

--- a/gen.py
+++ b/gen.py
@@ -56,7 +56,6 @@ repl["@SHA1_SHORT@"] = tag.commit.sha[0:10]
 repl["@DOC_URL@"] = "https://www.openmicroscopy.org/site/support/omero%s" % major_version
 if "STAGING" in os.environ and os.environ.get("STAGING"):
     repl["@DOC_URL@"] += "-staging"
-repl["@PDF_URL@"] = repl["@DOC_URL@"] + "/OMERO-%s.pdf" % version
 
 if "SNAPSHOT_PATH" in os.environ:
     SNAPSHOT_PATH =  os.environ.get('SNAPSHOT_PATH')

--- a/tmpl.txt
+++ b/tmpl.txt
@@ -15,7 +15,7 @@ major release of OMERO. Refer to the following sections for more information
 about each release.
 
  * After downloading the relevant files, you may want to take a look at our OMERO @VERSION@ [online documentation](@DOC_URL@) page or
-[PDF documentation](@PDF_URL@).
+[PDF documentation](/latest/omero-manual-pdf).
 
 ## OMERO client @VERSION@ downloads ##
 


### PR DESCRIPTION
Use the `/latest/*manual-pdf` link for the OMERO and Bio-Formats instead. This
allows a patch release such as 4.4.8.1 to keep pointing at the 4.4.8 PDF
documentation (assuming the redirected links are not updated).
Also remove the `PDF_URL` replacement key in gen.py and bfgen.py
