### PR TITLE
Refactor prep.sh to allow independent OMERO and Bio-Formats releases 

### DIFF
--- a/prep.sh
+++ b/prep.sh
@@ -41,7 +41,7 @@ fi
 
 # Create OMERO & Bio-Formats directories
 if [[ !  -z $OMERO_BUILD ]]; then
-    "Creating OMERO release directories"
+    echo "Creating OMERO release directories"
     OMERO_SNAPSHOT_PATH=$SNAPSHOT_PATH/omero
     [[ -d $OMERO_SNAPSHOT_PATH ]] ||  mkdir $OMERO_SNAPSHOT_PATH
     OMERO_VIRTUALBOX_PATH=$OMERO_SNAPSHOT_PATH/virtualbox
@@ -59,7 +59,7 @@ if [[ !  -z $OMERO_BUILD ]]; then
 fi
 
 if [[ ! -z $BIOFORMATS_BUILD ]]; then
-    "Creating Bio-Formats release directories"
+    echo "Creating Bio-Formats release directories"
     BIOFORMATS_SNAPSHOT_PATH=$SNAPSHOT_PATH/bioformats
     [[ -d $BIOFORMATS_SNAPSHOT_PATH ]] ||  mkdir $BIOFORMATS_SNAPSHOT_PATH
 

--- a/prep.sh
+++ b/prep.sh
@@ -19,53 +19,78 @@ ARTIFACT_PATH=${ARTIFACT_PATH:-/ome/data_repo/releases}
 SNAPSHOT_PATH=${SNAPSHOT_PATH:-/var/www/cvs.openmicroscopy.org.uk/snapshots}
 
 # Test artifact directory existence
-OMERO_ARTIFACT_PATH=$ARTIFACT_PATH/$OMERO_JOB/$OMERO_BUILD
-[[ -d $OMERO_ARTIFACT_PATH ]] || exit
-OMERO_ICE34_ARTIFACT_PATH=$ARTIFACT_PATH/$OMERO_ICE34_JOB/$OMERO_ICE34_BUILD
-[[ -d $OMERO_ICE34_ARTIFACT_PATH ]] || exit
-OMERO_VIRTUALBOX_ARTIFACT_PATH=$ARTIFACT_PATH/$OMERO_VIRTUALBOX_JOB/$OMERO_VIRTUALBOX_BUILD
-[[ -d $OMERO_VIRTUALBOX_ARTIFACT_PATH ]] || exit
-BIOFORMATS_ARTIFACT_PATH=$ARTIFACT_PATH/$BIOFORMATS_JOB/$BIOFORMATS_BUILD
-[[ -d $BIOFORMATS_ARTIFACT_PATH ]] || exit
-
-# Create OMERO & Bio-Formats directories
-OMERO_SNAPSHOT_PATH=$SNAPSHOT_PATH/omero
-[[ -d $OMERO_SNAPSHOT_PATH ]] ||  mkdir $OMERO_SNAPSHOT_PATH
-BIOFORMATS_SNAPSHOT_PATH=$SNAPSHOT_PATH/bioformats
-[[ -d $BIOFORMATS_SNAPSHOT_PATH ]] ||  mkdir $BIOFORMATS_SNAPSHOT_PATH
-OMERO_VIRTUALBOX_PATH=$OMERO_SNAPSHOT_PATH/virtualbox
-[[ -d $OMERO_VIRTUALBOX_PATH ]] ||  mkdir $OMERO_VIRTUALBOX_PATH
-
-# Create OMERO release directory
-OMERO_RELEASE_PATH=$OMERO_SNAPSHOT_PATH/$RELEASE
-if [[ -d $OMERO_RELEASE_PATH ]]
-then
-    echo "$OMERO_RELEASE_PATH already exists"
-    [ $FAIL_ON_DUPLICATES ] && exit
+if [[ -z $OMERO_BUILD ]] ; then
+    echo "Not releasing OMERO"
 else
-    mkdir $OMERO_RELEASE_PATH
+    echo "Checking OMERO artifacts"
+    OMERO_ARTIFACT_PATH=$ARTIFACT_PATH/$OMERO_JOB/$OMERO_BUILD
+    [[ -d $OMERO_ARTIFACT_PATH ]] || exit
+    OMERO_ICE34_ARTIFACT_PATH=$ARTIFACT_PATH/$OMERO_ICE34_JOB/$OMERO_ICE34_BUILD
+    [[ -d $OMERO_ICE34_ARTIFACT_PATH ]] || exit
+    OMERO_VIRTUALBOX_ARTIFACT_PATH=$ARTIFACT_PATH/$OMERO_VIRTUALBOX_JOB/$OMERO_VIRTUALBOX_BUILD
+    [[ -d $OMERO_VIRTUALBOX_ARTIFACT_PATH ]] || exit
 fi
 
-# Create Bio-Formats release directory
-BIOFORMATS_RELEASE_PATH=$BIOFORMATS_SNAPSHOT_PATH/$RELEASE
-if [[ -d $BIOFORMATS_RELEASE_PATH ]]
-then
-    echo "$BIOFORMATS_RELEASE_PATH already exists"
-    [ $FAIL_ON_DUPLICATES ] && exit
+if [[ -z $BIOFORMATS_BUILD ]]; then
+    echo "Not releasing Bio-Formats"
 else
-    mkdir $BIOFORMATS_RELEASE_PATH
+    echo "Checking Bio-Formats artifacts"
+    BIOFORMATS_ARTIFACT_PATH=$ARTIFACT_PATH/$BIOFORMATS_JOB/$BIOFORMATS_BUILD
+    [[ -d $BIOFORMATS_ARTIFACT_PATH ]] || exit
+fi
+
+# Create OMERO & Bio-Formats directories
+if [[ !  -z $OMERO_BUILD ]]; then
+    "Creating OMERO release directories"
+    OMERO_SNAPSHOT_PATH=$SNAPSHOT_PATH/omero
+    [[ -d $OMERO_SNAPSHOT_PATH ]] ||  mkdir $OMERO_SNAPSHOT_PATH
+    OMERO_VIRTUALBOX_PATH=$OMERO_SNAPSHOT_PATH/virtualbox
+    [[ -d $OMERO_VIRTUALBOX_PATH ]] ||  mkdir $OMERO_VIRTUALBOX_PATH
+
+    # Create OMERO release directory
+    OMERO_RELEASE_PATH=$OMERO_SNAPSHOT_PATH/$RELEASE
+    if [[ -d $OMERO_RELEASE_PATH ]]
+    then
+        echo "$OMERO_RELEASE_PATH already exists"
+        [ $FAIL_ON_DUPLICATES ] && exit
+    else
+        mkdir $OMERO_RELEASE_PATH
+    fi
+fi
+
+if [[ ! -z $BIOFORMATS_BUILD ]]; then
+    "Creating Bio-Formats release directories"
+    BIOFORMATS_SNAPSHOT_PATH=$SNAPSHOT_PATH/bioformats
+    [[ -d $BIOFORMATS_SNAPSHOT_PATH ]] ||  mkdir $BIOFORMATS_SNAPSHOT_PATH
+
+    # Create Bio-Formats release directory
+    BIOFORMATS_RELEASE_PATH=$BIOFORMATS_SNAPSHOT_PATH/$RELEASE
+    if [[ -d $BIOFORMATS_RELEASE_PATH ]]
+    then
+        echo "$BIOFORMATS_RELEASE_PATH already exists"
+        [ $FAIL_ON_DUPLICATES ] && exit
+    else
+        mkdir $BIOFORMATS_RELEASE_PATH
+    fi
 fi
 
 # Symlink artifacts into release directories
-for x in $OMERO_ARTIFACT_PATH/*;
-    do ln -sf "$x" "$OMERO_RELEASE_PATH/";
-done
-for x in $OMERO_ICE34_ARTIFACT_PATH/*;
-    do ln -sf "$x" "$OMERO_RELEASE_PATH/";
-done
-for x in $OMERO_VIRTUALBOX_ARTIFACT_PATH/*;
-    do ln -sf "$x" "$OMERO_VIRTUALBOX_PATH/";
-done
-for x in $BIOFORMATS_ARTIFACT_PATH/*;
-    do ln -sf "$x" "$BIOFORMATS_RELEASE_PATH/";
-done
+if [[ ! -z $OMERO_BUILD ]]; then
+    echo "Symlinking OMERO artifacts"
+    for x in $OMERO_ARTIFACT_PATH/*;
+        do ln -sf "$x" "$OMERO_RELEASE_PATH/";
+    done
+    for x in $OMERO_ICE34_ARTIFACT_PATH/*;
+        do ln -sf "$x" "$OMERO_RELEASE_PATH/";
+    done
+    for x in $OMERO_VIRTUALBOX_ARTIFACT_PATH/*;
+        do ln -sf "$x" "$OMERO_VIRTUALBOX_PATH/";
+    done
+fi
+
+if [[ ! -z $BIOFORMATS_BUILD ]]; then
+    echo "Symlinking Bio-Formats artifacts"
+    for x in $BIOFORMATS_ARTIFACT_PATH/*;
+        do ln -sf "$x" "$BIOFORMATS_RELEASE_PATH/";
+    done
+fi


### PR DESCRIPTION
Test the emptiness of the `OMERO_BUILD` and `BIOFORMATS_BUILD` variables to determine the components to be prepared for release.
For each components, the artifacts checking, the release directory creation and the artifacts symlinking are conditioned by the existence of the corresponding build variable.
