### PR TITLE
Changes for the 5.0.0-beta2 pages

### DIFF
--- a/bfgen.py
+++ b/bfgen.py
@@ -53,7 +53,7 @@ major_version = int(split_version[1])
 # repl["@SHA1_FULL@"] = tag.commit.sha
 # repl["@SHA1_SHORT@"] = tag.commit.sha[0:10]
 repl["@DOC_URL@"] = \
-    "https://www.openmicroscopy.org/site/support/bio-formats%s" \
+    "http://www.openmicroscopy.org/site/support/bio-formats%s" \
     % major_version
 if "STAGING" in os.environ and os.environ.get("STAGING"):
     repl["@DOC_URL@"] += "-staging"

--- a/bfgen.py
+++ b/bfgen.py
@@ -75,7 +75,6 @@ for x, y in (
         ("ome-io.jar", "artifacts/ome-io.jar"),
         ("ome-xml.jar", "artifacts/ome-xml.jar"),
         ("ome_plugins.jar", "artifacts/ome_plugins.jar"),
-        ("ome-editor.jar", "artifacts/ome-editor.jar"),
         ("poi-loci.jar", "artifacts/poi-loci.jar"),
         ("jai_imageio.jar", "artifacts/jai_imageio.jar"),
         ("lwf-stubs.jar", "artifacts/lwf-stubs.jar"),
@@ -86,6 +85,11 @@ for x, y in (
         ("loci_plugins.jar", "artifacts/loci_plugins.jar"),
         ("loci-testing-framework.jar",
          "artifacts/loci-testing-framework.jar"),
+        ("loci-legacy.jar", "artifacts/loci-legacy.jar"),
+        ("scifio-devel.jar", "artifacts/scifio-devel.jar"),
+        ("scifio-test.jar", "artifacts/scifio-test.jar"),
+        ("specification.jar", "artifacts/specification.jar"),
+        ("turbojpeg.jar", "artifacts/turbojpeg.jar"),
         ("DOC", "artifacts/Bio-Formats-@VERSION@.pdf")):
 
     find_pkg(repl, fingerprint_url, BF_SNAPSHOT_PATH, x, y, MD5s)

--- a/bftmpl.txt
+++ b/bftmpl.txt
@@ -15,7 +15,7 @@ Please note:
 * Internet Explorer sometimes renames JAR files to ZIP (e.g. loci_tools.jar becomes loci_tools.zip); if this happens to you, simply rename the file back to its original name after the download is complete.
 * For some browsers, you may need to right-click or control-click the link and choose "Save link as..." or a similar option to download the file.
 
-After downloading the relevant files, you may want to take a look at our Bio-Formats @VERSION@ [online documentation](@DOC_URL@) page or at the [PDF documentation](@DOC@).
+After downloading the relevant files, you may want to take a look at our Bio-Formats @VERSION@ [online documentation](@DOC_URL@) or at the [PDF documentation](@DOC@).
 
 
 ## Bio-Formats trunk/daily builds ##

--- a/bftmpl.txt
+++ b/bftmpl.txt
@@ -68,7 +68,7 @@ Developers can access builds of individual JAR libraries below.
 <td><a href="@DAILY_loci-legacy.jar@">loci-legacy.jar</a></td>
 </tr>
 <tr>
-<td>SCIFIO Developer library</td>
+<td>SCIFIO Development library</td>
 <td><a href="@scifio-devel.jar@">scifio-devel.jar</a></td>
 <td><a href="@TRUNK_scifio-devel.jar@">scifio-devel.jar</a></td>
 <td><a href="@DAILY_scifio-devel.jar@">scifio-devel.jar</a></td>
@@ -80,7 +80,7 @@ Developers can access builds of individual JAR libraries below.
 <td><a href="@DAILY_scifio-test.jar@">scifio-test.jar</a></td>
 </tr>
 <tr>
-<td>Specification</td>
+<td>OME Model Specification</td>
 <td><a href="@specification.jar@">specification.jar</a></td>
 <td><a href="@TRUNK_specification.jar@">specification.jar</a></td>
 <td><a href="@DAILY_specification.jar@">specification.jar</a></td>

--- a/bftmpl.txt
+++ b/bftmpl.txt
@@ -62,6 +62,30 @@ Developers can access builds of individual JAR libraries below.
 <td><a href="@DAILY_ome-xml.jar@">ome-xml.jar</a></td>
 </tr>
 <tr>
+<td>LOCI Legacy</td>
+<td><a href="@loci-legacy.jar@">loci-legacy.jar</a></td>
+<td><a href="@TRUNK_loci-legacy.jar@">loci-legacy.jar</a></td>
+<td><a href="@DAILY_loci-legacy.jar@">loci-legacy.jar</a></td>
+</tr>
+<tr>
+<td>SCIFIO Developer library</td>
+<td><a href="@scifio-devel.jar@">scifio-devel.jar</a></td>
+<td><a href="@TRUNK_scifio-devel.jar@">scifio-devel.jar</a></td>
+<td><a href="@DAILY_scifio-devel.jar@">scifio-devel.jar</a></td>
+</tr>
+<tr>
+<td>SCIFIO Test library</td>
+<td><a href="@scifio-test.jar@">scifio-test.jar</a></td>
+<td><a href="@TRUNK_scifio-test.jar@">scifio-test.jar</a></td>
+<td><a href="@DAILY_scifio-test.jar@">scifio-test.jar</a></td>
+</tr>
+<tr>
+<td>Specification</td>
+<td><a href="@specification.jar@">specification.jar</a></td>
+<td><a href="@TRUNK_specification.jar@">specification.jar</a></td>
+<td><a href="@DAILY_specification.jar@">specification.jar</a></td>
+</tr>
+<tr>
 <td>LOCI Plugins for ImageJ</td>
 <td><a href="@loci_plugins.jar@">loci_plugins.jar</a></td>
 <td><a href="@TRUNK_loci_plugins.jar@">loci_plugins.jar</a></td>
@@ -119,6 +143,12 @@ Developers can access builds of individual JAR libraries below.
 <td><a href="@DAILY_poi-loci.jar@">poi-loci.jar</a></td>
 </tr>
 <tr>
+<td>TurboJPEG</td>
+<td><a href="@turbojpeg.jar@">turbojpeg.jar</a></td>
+<td><a href="@TRUNK_turbojpeg.jar@">turbojpeg.jar</a></td>
+<td><a href="@DAILY_turbojpeg.jar@">turbojpeg.jar</a></td>
+</tr>
+<tr>
 <th align="center" colspan="4">Stubs</th>
 </tr>
 <tr>
@@ -126,15 +156,6 @@ Developers can access builds of individual JAR libraries below.
 <td><a href="@lwf-stubs.jar@">lwf-stubs.jar</a></td>
 <td><a href="@TRUNK_lwf-stubs.jar@">lwf-stubs.jar</a></td>
 <td><a href="@DAILY_lwf-stubs.jar@">lwf-stubs.jar</a></td>
-</tr>
-<tr>
-<th align="center" colspan="4">Legacy</th>
-</tr>
-<tr>
-<td>OME Metadata Editor</td>
-<td><a href="@ome-editor.jar@">ome-editor.jar</a></td>
-<td>--</td>
-<td>--</td>
 </tr>
 </table>
 </div>

--- a/gen.py
+++ b/gen.py
@@ -51,7 +51,7 @@ for repo in (repo1, repo2):
         break
 
 repl["@TAG_URL@"] = repo.html_url + '/tree/' + tag.name
-repl["@DOC_URL@"] = "https://www.openmicroscopy.org/site/support/omero%s" \
+repl["@DOC_URL@"] = "http://www.openmicroscopy.org/site/support/omero%s" \
     % major_version
 if "STAGING" in os.environ and os.environ.get("STAGING"):
     repl["@DOC_URL@"] += "-staging"

--- a/gen.py
+++ b/gen.py
@@ -42,6 +42,7 @@ repo1 = gh.get_organization(ome).get_repo(ome)
 repo2 = gh.get_user(scc).get_repo(ome)
 
 for repo in (repo1, repo2):
+    found = False
     for tag in repo.get_tags():
         if tag.name == ("v.%s" % version):
             found = True

--- a/gen.py
+++ b/gen.py
@@ -53,8 +53,6 @@ for repo in (repo1, repo2):
 repl["@TAG_URL@"] = repo.html_url + '/tree/' + tag.name
 repl["@DOC_URL@"] = "http://www.openmicroscopy.org/site/support/omero%s" \
     % major_version
-if "STAGING" in os.environ and os.environ.get("STAGING"):
-    repl["@DOC_URL@"] += "-staging"
 
 if "SNAPSHOT_PATH" in os.environ:
     SNAPSHOT_PATH = os.environ.get('SNAPSHOT_PATH')

--- a/gen.py
+++ b/gen.py
@@ -53,6 +53,8 @@ for repo in (repo1, repo2):
 repl["@TAG_URL@"] = repo.html_url + '/tree/' + tag.name
 repl["@DOC_URL@"] = "http://www.openmicroscopy.org/site/support/omero%s" \
     % major_version
+repl["@HELP_URL@"] = "http://help.openmicroscopy.org/getting-started-%s.html"\
+    % major_version
 
 if "SNAPSHOT_PATH" in os.environ:
     SNAPSHOT_PATH = os.environ.get('SNAPSHOT_PATH')

--- a/omero_downloads.html
+++ b/omero_downloads.html
@@ -54,8 +54,8 @@
 <a href="@DOC@">PDF documentation</a> and there are user guides for the clients on our <a href="http://help.openmicroscopy.org">Help website</a></p>
 </li>
 <li>
-<p>A standard OMERO user just needs to download the client package with the same major version as their institutional server  e.g.  4.4 
-clients with the 4.4 server</p>
+<p>A standard OMERO user just needs to download the client package with the same major version as their institutional server  e.g. 5.0
+clients with the 5.0 server</p>
 </li>
 </ul>
 
@@ -101,7 +101,7 @@ clients with the 4.4 server</p>
 Java Version <strong>1.6</strong> or higher. OMERO.web is part of the server package, so individual users do not need to install it locally.</p>
 </li>
 <li>
-<p>Full instructions for installing the clients are on the Help website: <a href="http://help.openmicroscopy.org/getting-started-4.html" target="_blank">Getting Started with OMERO.insight Version 4.4.9</a></p>
+<p>Full instructions for installing the clients are on the Help website: <a href="http://help.openmicroscopy.org/getting-started-4.html" target="_blank">Getting Started with OMERO.insight Version @VERSION@</a></p>
 </li>
 </ul>
 
@@ -155,7 +155,7 @@ Java Version <strong>1.6</strong> or higher. OMERO.web is part of the server pac
   </li>
 </ul>
 
-<h2><a name="servers" id="servers"></a>OMERO server 4.4.9 downloads</h2>
+<h2><a name="servers" id="servers"></a>OMERO server @VERSION@ downloads</h2>
 <div class="alt-table">
 <table width="800" border="0" cellpadding="5">
   <tbody>

--- a/omero_downloads.html
+++ b/omero_downloads.html
@@ -101,7 +101,7 @@ clients with the 5.0 server</p>
 Java Version <strong>1.6</strong> or higher. OMERO.web is part of the server package, so individual users do not need to install it locally.</p>
 </li>
 <li>
-<p>Full instructions for installing the clients are on the Help website: <a href="http://help.openmicroscopy.org/getting-started-4.html" target="_blank">Getting Started with OMERO.insight Version @VERSION@</a></p>
+<p>Full instructions for installing the clients are on the Help website: <a href="@HELP_URL@" target="_blank">Getting Started with OMERO.insight Version @VERSION@</a></p>
 </li>
 </ul>
 

--- a/omero_downloads.html
+++ b/omero_downloads.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<!-- saved from url=(0048)http://downloads.openmicroscopy.org/omero/4.4.9/ -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
         
         <link rel="stylesheet" href="images/plonematch.css" type="text/css">
@@ -40,7 +39,7 @@
 
 <div class="entry-content">
 
-<h2>OMERO 4.4.9 Downloads</h2>
+<h2>OMERO @VERSION@ Downloads</h2>
 
 <p>
   <strong><a href="#clients">Clients</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#plugins">Plugins</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#additional">Additional</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#servers">Servers</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#va">Virtual Appliance</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#api">API</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#code">Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#legacy">Legacy</a> </strong></p>

--- a/omero_downloads.html
+++ b/omero_downloads.html
@@ -50,7 +50,7 @@
 </li>
 
 <li>
-<p>Full documentation is available as <a href="http://www.openmicroscopy.org/site/support/omero4">web documentation</a>  or
+<p>Full documentation is available as <a href="@DOC_URL@">web documentation</a>  or
 <a href="@DOC@">PDF documentation</a> and there are user guides for the clients on our <a href="http://help.openmicroscopy.org">Help website</a></p>
 </li>
 <li>
@@ -95,9 +95,9 @@ clients with the 5.0 server</p>
 <ul>
 <li>
 <p>Each client package includes 
-<a href="http://www.openmicroscopy.org/site/support/omero4/users/clients-overview.html#omero-insight">OMERO.insight</a>, 
-<a href="http://www.openmicroscopy.org/site/support/omero4/users/clients-overview.html#omero-importer">OMERO.importer</a> and 
-<a href="http://www.openmicroscopy.org/site/support/omero4/users/clients-overview.html#omero-editor">OMERO.editor</a> and requires 
+<a href="@DOC_URL@/users/clients-overview.html#omero-insight">OMERO.insight</a>, 
+<a href="@DOC_URL@/users/clients-overview.html#omero-importer">OMERO.importer</a> and 
+<a href="@DOC_URL@/users/clients-overview.html#omero-editor">OMERO.editor</a> and requires 
 Java Version <strong>1.6</strong> or higher. OMERO.web is part of the server package, so individual users do not need to install it locally.</p>
 </li>
 <li>
@@ -138,7 +138,7 @@ Java Version <strong>1.6</strong> or higher. OMERO.web is part of the server pac
 </li>
 <li>
 <p>Instructions for using the Matlab plugin are at:
-<a href="http://www.openmicroscopy.org/site/support/omero4/developers/Matlab.html">OMERO Matlab language bindings</a></p>
+<a href="@DOC_URL@/developers/Matlab.html">OMERO Matlab language bindings</a></p>
 </li>
 </ul>
 
@@ -194,12 +194,12 @@ Java Version <strong>1.6</strong> or higher. OMERO.web is part of the server pac
   should work with any version of the server)</p>
 </li>
 <li>
-<p>Installation instructions are available for: <a href="http://www.openmicroscopy.org/site/support/omero4/sysadmins/unix/server-installation.html">Unix  
-platforms</a>, <a href="http://www.openmicroscopy.org/site/support/omero4/sysadmins/windows/server-installation.html">Microsoft 
+<p>Installation instructions are available for: <a href="@DOC_URL@/sysadmins/unix/server-installation.html">Unix  
+platforms</a>, <a href="@DOC_URL@/sysadmins/windows/server-installation.html">Microsoft 
 Windows</a> </p>
 </li>
 <li>
-  <p>Server upgrade instructions are at: <a href="http://www.openmicroscopy.org/site/support/omero4/sysadmins/server-upgrade.html">OMERO.server upgrade</a></p>
+  <p>Server upgrade instructions are at: <a href="@DOC_URL@/sysadmins/server-upgrade.html">OMERO.server upgrade</a></p>
 </ul>
 
 
@@ -228,7 +228,7 @@ Windows</a> </p>
   <p>The OMERO Virtual Appliance allows you to try out an OMERO server on your local machine </p>
   </li>
   <li>
-    <p>Instructions for using the Virtual Appliance are at: <a href="http://www.openmicroscopy.org/site/support/omero4/users/virtual-appliance.html">Virtual Appliance</a></p>
+    <p>Instructions for using the Virtual Appliance are at: <a href="@DOC_URL@/users/virtual-appliance.html">Virtual Appliance</a></p>
   </li>
 </ul>
 
@@ -275,7 +275,7 @@ Windows</a> </p>
 </div>
 <ul>
   <li>
-<p>Instructions for installing the source code can be found at: <a href="http://www.openmicroscopy.org/site/support/omero4/developers/installation.html" target="_blank">Installing OMERO from source</a></p>
+<p>Instructions for installing the source code can be found at: <a href="@DOC_URL@/developers/installation.html" target="_blank">Installing OMERO from source</a></p>
     </li>
 </ul>
 


### PR DESCRIPTION
This PR 
- backports some changes from #12 (in 5.0.0-beta1) tag to handle new 5.0-specific JARs in BF downloads page
- fix non initialized variable when tag is only present on the snoopycrimecop remote
- remove hard-coded versions from `omero_downloads.html`
