### PR TITLE
Add links to the API documentation to the downloads page (rebased onto dev_5_0)

### DIFF
--- a/bf_downloads.html
+++ b/bf_downloads.html
@@ -49,6 +49,9 @@
 <p>Full documentation is available as <a href="@DOC_URL@">web documentation</a> or <a href="@DOC@">PDF documentation</a>.</p>
 </li>
 <li>
+<p>The Bio-Formats API documentation is available <a href="api">here</a></p>
+</li>
+<li>
 <p>Internet Explorer sometimes renames JAR files to ZIP (e.g., loci_tools.jar becomes loci_tools.zip); if this happens to you, simply rename the file back to its original name after the download is complete.</p>
 </li>
 <li>

--- a/bf_downloads.html
+++ b/bf_downloads.html
@@ -49,7 +49,7 @@
 <p>Full documentation is available as <a href="@DOC_URL@">web documentation</a> or <a href="@DOC@">PDF documentation</a>.</p>
 </li>
 <li>
-<p>The Bio-Formats API documentation is available <a href="api">here</a></p>
+<p>The Bio-Formats API documentation is available to read on the web <a href="api">here</a>.</p>
 </li>
 <li>
 <p>Internet Explorer sometimes renames JAR files to ZIP (e.g., loci_tools.jar becomes loci_tools.zip); if this happens to you, simply rename the file back to its original name after the download is complete.</p>

--- a/omero_downloads.html
+++ b/omero_downloads.html
@@ -257,7 +257,10 @@ Windows</a> </p>
 
 <ul>
   <li>
-<p>Other versions of the API documentation are available <a href="artifacts">here</a></p>
+  <p>The OMERO API documentation is available <a href="api">here</a></p>
+  </li>
+  <li>
+  <p>Other versions of the API documentation are available <a href="artifacts">here</a></p>
   </li>
 </ul>
 

--- a/omero_downloads.html
+++ b/omero_downloads.html
@@ -257,10 +257,10 @@ Windows</a> </p>
 
 <ul>
   <li>
-  <p>The OMERO API documentation is available <a href="api">here</a></p>
+  <p>The OMERO API documentation is also available to read on the web <a href="api">here</a></p>
   </li>
   <li>
-  <p>Other versions of the API documentation are available <a href="artifacts">here</a></p>
+  <p>Zipped files of API documentation for other versions of Ice are available as part of the <a href="#artifacts">build artifacts</a></p>
   </li>
 </ul>
 


### PR DESCRIPTION
This is the same as gh-34 but rebased onto dev_5_0.

---

The API documentation is now synced to `downloads.openmicroscopy.org/{omero,bio-formats}/{$version}/api` as part of the release job process. 
This commit adds some links to this API documentation from the corresponding downloads page.

/cc @hflynn
