### PR TITLE
Adding Demo server & VA text to OMERO downloads page (rebased onto develop)

### DIFF
--- a/omero_downloads.html
+++ b/omero_downloads.html
@@ -57,6 +57,9 @@
 <p>A standard OMERO user just needs to download the client package with the same major version as their institutional server  e.g. 5.0
 clients with the 5.0 server</p>
 </li>
+<li>
+<p>If you do not have an institutional server, you can apply for an <a href="http://qa.openmicroscopy.org.uk/registry/demo_account/">account on our Demo server</a> or download the <a href="#va">Virtual Appliance</a> to install your own version locally.</p>
+</li>
 </ul>
 
 


### PR DESCRIPTION
This is the same as gh-52 but rebased onto develop.

---

Graeme Ball suggested we add some directions for people reaching the downloads page who don't have an institutional server and explain what the VA is for those who come here without reading the documentation.
cc @pwalczysko
