### PR TITLE
Map new environment variables from release jobs (rebased onto develop)

### DIFF
--- a/bfgen.py
+++ b/bfgen.py
@@ -58,13 +58,9 @@ repl["@DOC_URL@"] = \
     "http://www.openmicroscopy.org/site/support/bio-formats%s" \
     % major_version
 
-if "SNAPSHOT_PATH" in os.environ:
-    SNAPSHOT_PATH = os.environ.get('SNAPSHOT_PATH')
-else:
-    SNAPSHOT_PATH = "/ome/data_repo/public/"
-
-
-BF_SNAPSHOT_PATH = SNAPSHOT_PATH + "/bio-formats/" + version + "/"
+RSYNC_PATH = os.environ.get('RSYNC_PATH', '/ome/data_repo/public/')
+PREFIX = os.environ.get('PREFIX', 'bio-formats')
+BF_RSYNC_PATH = '%s/%s/%s/' % (RSYNC_PATH, PREFIX, version)
 
 for x, y in (
         ("BF_PACKAGE", "artifacts/bioformats_package.jar"),
@@ -95,7 +91,7 @@ for x, y in (
         ("turbojpeg.jar", "artifacts/turbojpeg.jar"),
         ):
 
-    find_pkg(repl, fingerprint_url, BF_SNAPSHOT_PATH, x, y, MD5s)
+    find_pkg(repl, fingerprint_url, BF_RSYNC_PATH, x, y, MD5s)
 
     repl["@DAILY_%s@" % x] = "%s/%s" % (daily_url, x)
     repl["@LATEST_%s@" % x] = "%s/%s" % (latest_url, x)

--- a/gen.py
+++ b/gen.py
@@ -56,23 +56,13 @@ repl["@DOC_URL@"] = "http://www.openmicroscopy.org/site/support/omero%s" \
 repl["@HELP_URL@"] = "http://help.openmicroscopy.org/getting-started-%s.html"\
     % major_version
 
-if "SNAPSHOT_PATH" in os.environ:
-    SNAPSHOT_PATH = os.environ.get('SNAPSHOT_PATH')
-else:
-    SNAPSHOT_PATH = "/ome/data_repo/public/"
+RSYNC_PATH = os.environ.get('RSYNC_PATH', '/ome/data_repo/public/')
+PREFIX = os.environ.get('PREFIX', 'omero')
+OMERO_RSYNC_PATH = '%s/%s/%s/' % (RSYNC_PATH, PREFIX, version)
 
-OMERO_SNAPSHOT_PATH = SNAPSHOT_PATH + "/omero/" + version + "/"
-
-if "ANNOUCEMENT_URL" in os.environ:
-    repl["@ANNOUCEMENT_URL@"] = os.environ.get('ANNOUCEMENT_URL')
-else:
-    repl["@ANNOUCEMENT_URL@"] = \
-        "https://www.openmicroscopy.org/community/viewforum.php?f=11"
-
-if "MILESTONE" in os.environ:
-    repl["@MILESTONE@"] = os.environ.get('MILESTONE')
-else:
-    repl["@MILESTONE@"] = "OMERO-%s" % version
+forum_url = "https://www.openmicroscopy.org/community/viewforum.php?f=11"
+repl["@ANNOUCEMENT_URL@"] = os.environ.get('ANNOUCEMENT_URL', forum_url)
+repl["@MILESTONE@"] = os.environ.get('MILESTONE', "OMERO-%s" % version)
 
 for x, y in (
         ("LINUX_CLIENTS",
@@ -94,7 +84,7 @@ for x, y in (
         ("SOURCE_CODE", "artifacts/openmicroscopy-@VERSION@.zip"),
         ):
 
-    find_pkg(repl, fingerprint_url, OMERO_SNAPSHOT_PATH, x, y, MD5s)
+    find_pkg(repl, fingerprint_url, OMERO_RSYNC_PATH, x, y, MD5s)
 
 
 for line in fileinput.input(["omero_downloads.html"]):


### PR DESCRIPTION
This is the same as gh-55 but rebased onto develop.

---
- Use new environment variables (RSYNC_PATH, PREFIX)
- Use os.environ.get(VAR, default) to simplify logic
