### PR TITLE
Add first version of u-track downloads page (rebased onto develop)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ bf: bfgen
 
 flimfit: flimfitgen
 
+utrack: utrackgen
+
 gen:
 	mkdir -p $(CONTENTDIR)
 	python gen.py $(RELEASE) $(OMERO_BUILD) > $(CONTENTDIR)/index.html
@@ -33,6 +35,11 @@ bfgen:
 flimfitgen:
 	mkdir -p $(CONTENTDIR)
 	python flimfitgen.py $(RELEASE) > $(CONTENTDIR)/index.html
+	cp -r $(IMAGESDIR) $(CONTENTDIR)
+
+utrackgen:
+	mkdir -p $(CONTENTDIR)
+	python utrackgen.py $(RELEASE) > $(CONTENTDIR)/index.html
 	cp -r $(IMAGESDIR) $(CONTENTDIR)
 
 html:

--- a/utrack_downloads.html
+++ b/utrack_downloads.html
@@ -40,22 +40,13 @@
 
 <h2>u-track @VERSION@ Downloads</h2>
 
-<p>
-  <strong><a href="#code">Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#legacy">Previous versions</a> </strong></p>
-
 <ul>
 <li>
-<p>The software is currently distributed as a source code bundle and requires MATLAB to be installed with some toolboxes described in the documentation.</a>.</p>
-</li>
-<li>
-<p>Full documentation is available as <a href="@DOC@">PDF documentation</a>.</p>
-</li>
-<li>
-<p>To use u-track without OMERO, you will need to download the OMERO.matlab toolbox corresponding to your server in addition to the u-track source code.</p>
+<p>The software is currently distributed as a source code bundle and requires MATLAB to be installed with some toolboxes described in the <a href="@DOC@">PDF documentation</a>.</p>
 </li>
 </ul>
 
-<h2><a name="code" id="code"></a>Source code</h2>
+<h2><a name="code" id="code"></a>Downloads</h2>
 
 <div class="alt-table">
 <table width="800" border="0" cellpadding="5">
@@ -75,6 +66,16 @@
   </tbody>
 </table>
 </div>
+
+<ul>
+<li>
+<p>To use u-track with OMERO, you will need to download the OMERO.matlab toolbox corresponding to your server in addition to the source code.</p>
+</li>
+<li>
+<p>To get started, download the zipped code, unextract it and add it to your MATLAB path. Then start the software by entering <code>movieSelectorGUI</code> at the MATLAB command prompt.</p>
+</li>
+
+</ul>
 
 <h2><a name="legacy" id="legacy"></a>Previous versions</h2>
 

--- a/utrack_downloads.html
+++ b/utrack_downloads.html
@@ -38,7 +38,7 @@
 
 <div class="entry-content">
 
-<h2>U-Track @VERSION@ Downloads</h2>
+<h2>u-track @VERSION@ Downloads</h2>
 
 <p>
   <strong><a href="#code">Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#legacy">Previous versions</a> </strong></p>
@@ -67,10 +67,10 @@
       <th width="120">Checksum</th>
       </tr>
     <tr>
-      <td><a href="@UTRACK_SOURCE_CODE@" target="_blank"><img src="images/ome_source_code.png" alt="Zipped Source Code" /></a></td>
-      <td align="center">@UTRACK_SOURCE_CODE_SIZE@</td>
-      <td>@UTRACK_SOURCE_CODE_BASE@</td>
-      <td align="center">@UTRACK_SOURCE_CODE_MD5@ (<a href="@UTRACK_SOURCE_CODE@.md5">MD5</a>)</td>
+      <td><a href="@SOURCE_CODE@" target="_blank"><img src="images/ome_source_code.png" alt="Zipped Source Code" /></a></td>
+      <td align="center">@SOURCE_CODE_SIZE@</td>
+      <td>@SOURCE_CODE_BASE@</td>
+      <td align="center">@SOURCE_CODE_MD5@ (<a href="@SOURCE_CODE@.md5">MD5</a>)</td>
       </tr>
   </tbody>
 </table>

--- a/utrack_downloads.html
+++ b/utrack_downloads.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+        
+        <link rel="stylesheet" href="images/plonematch.css" type="text/css">
+        <meta charset="utf-8">
+          
+  
+      <meta name="tags" contents="flimfit">
+  
+    <style type="text/css"></style><style>[touch-action="none"]{ -ms-touch-action: none; touch-action: none; }[touch-action="pan-x"]{ -ms-touch-action: pan-x; touch-action: pan-x; }[touch-action="pan-y"]{ -ms-touch-action: pan-y; touch-action: pan-y; }[touch-action="scroll"],[touch-action="pan-x pan-y"],[touch-action="pan-y pan-x"]{ -ms-touch-action: pan-x pan-y; touch-action: pan-x pan-y; }</style></head>
+    <body id="index" class="home">
+
+		<!-- OME Banner - START -->
+		<div id="portal-top">
+			<div id="portal-header">
+				<ul id="portal-siteactions">
+					<li>
+						<br>
+					</li>
+				</ul><a id="portal-logo" accesskey="1" href="http://downloads.openmicroscopy.org/" name="portal-logo"><img src="images/logo.jpg" alt="" title="" height="73" width="450"></a>
+			  <div id="portal-globalnav">
+					<br>
+				</div>
+			</div>
+			<div id="portal-personaltools-wrapper">
+				<ul id="portal-personaltools" class="visualInline">
+					<li>
+						<br>
+					</li>
+				</ul>
+			</div>
+		</div>
+		<div class="visualClear" id="clear-space-before-wrapper-table">
+		<!-- OME Banner - END -->
+
+                                  <!-- /#menu -->
+<section id="content" class="body" style="margin-left:20px;">
+
+<div class="entry-content">
+
+<h2>U-Track @VERSION@ Downloads</h2>
+
+<p>
+  <strong><a href="#code">Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#legacy">Previous versions</a> </strong></p>
+
+<ul>
+<li>
+<p>The software is currently distributed as a source code bundle and requires MATLAB to be installed with some toolboxes described in the documentation.</a>.</p>
+</li>
+<li>
+<p>Full documentation is available as <a href="@DOC@">PDF documentation</a>.</p>
+</li>
+<li>
+<p>To use u-track without OMERO, you will need to download the OMERO.matlab toolbox corresponding to your server in addition to the u-track source code.</p>
+</li>
+</ul>
+
+<h2><a name="code" id="code"></a>Source code</h2>
+
+<div class="alt-table">
+<table width="800" border="0" cellpadding="5">
+  <tbody>
+    <tr>
+      <th width="269">Source Code</th>
+      <th width="91">Size</th>
+      <th width="270">File Name</th>
+      <th width="120">Checksum</th>
+      </tr>
+    <tr>
+      <td><a href="@UTRACK_SOURCE_CODE@" target="_blank"><img src="images/ome_source_code.png" alt="Zipped Source Code" /></a></td>
+      <td align="center">@UTRACK_SOURCE_CODE_SIZE@</td>
+      <td>@UTRACK_SOURCE_CODE_BASE@</td>
+      <td align="center">@UTRACK_SOURCE_CODE_MD5@ (<a href="@UTRACK_SOURCE_CODE@.md5">MD5</a>)</td>
+      </tr>
+  </tbody>
+</table>
+</div>
+
+<h2><a name="legacy" id="legacy"></a>Previous versions</h2>
+
+<ul>
+  <li>
+<p>We recommend that you always use the most recent release version of the u-track software, but if you need to use a previous version,  they are all available from the main <a href="http://downloads.openmicroscopy.org/u-track/?C=M;O=D">downloads folder</a></p>
+  </li>
+</ul>
+  
+  </div><!-- /.entry-content -->
+</section>
+        <footer id="contentinfo" class="body">
+        </footer><!-- /#contentinfo -->
+
+		<!-- OME Footer - Start -->
+		<div class="visualClear" id="clear-space-before-footer"><!-- --></div>
+		<div id="portal-footer">
+			<p>
+				<acronym title="Copyright">&copy;</acronym>
+				2000-2014
+				University of Dundee &amp; Open Microscopy Environment. <a href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing">Creative Commons Attribution 3.0 Unported License</a>
+			</p>
+			<p>
+				OME source code is available under the <a href="http://www.openmicroscopy.org/site/about/licensing">GNU General public license</a> or through commercial license from <a href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software">Glencoe Software</a>
+			</p>
+		</div>
+		<div class="visualClear">
+		<!-- OME Footer - END -->
+	
+</div></div></body></html>

--- a/utrack_downloads.html
+++ b/utrack_downloads.html
@@ -69,7 +69,7 @@
 
 <ul>
 <li>
-<p>To use u-track with OMERO, you will need to download the OMERO.matlab toolbox corresponding to your server from the <a href="http://downloads.openmicroscopy.org/omero">OMERO downloads folders</a> in addition to the zipped code.</p>
+<p>To use u-track with OMERO, you will need to download the OMERO.matlab toolbox for the same OMERO release number as your server from the <a href="http://downloads.openmicroscopy.org/omero">OMERO downloads folders</a> in addition to the zipped code.</p>
 </li>
 <li>
 <p>To get started, download the zipped code, unextract it and add it with its subfolders to your MATLAB path. Then launch the software by entering <code>movieSelectorGUI</code> at the MATLAB command prompt.</p>

--- a/utrack_downloads.html
+++ b/utrack_downloads.html
@@ -69,10 +69,10 @@
 
 <ul>
 <li>
-<p>To use u-track with OMERO, you will need to download the OMERO.matlab toolbox corresponding to your server in addition to the source code.</p>
+<p>To use u-track with OMERO, you will need to download the OMERO.matlab toolbox corresponding to your server from the <a href="http://downloads.openmicroscopy.org/omero">OMERO downloads folders</a> in addition to the zipped code.</p>
 </li>
 <li>
-<p>To get started, download the zipped code, unextract it and add it to your MATLAB path. Then start the software by entering <code>movieSelectorGUI</code> at the MATLAB command prompt.</p>
+<p>To get started, download the zipped code, unextract it and add it with its subfolders to your MATLAB path. Then launch the software by entering <code>movieSelectorGUI</code> at the MATLAB command prompt.</p>
 </li>
 
 </ul>
@@ -81,7 +81,7 @@
 
 <ul>
   <li>
-<p>We recommend that you always use the most recent release version of the u-track software, but if you need to use a previous version,  they are all available from the main <a href="http://downloads.openmicroscopy.org/u-track/?C=M;O=D">downloads folder</a></p>
+<p>We recommend that you always use the most recent release version of the u-track software, but if you need to use a previous version, they are all available from the main <a href="http://downloads.openmicroscopy.org/u-track/?C=M;O=D">downloads folder</a></p>.
   </li>
 </ul>
   

--- a/utrackgen.py
+++ b/utrackgen.py
@@ -31,8 +31,8 @@ PREFIX = os.environ.get('PREFIX', 'u-track')
 UTRACK_RSYNC_PATH = '%s/%s/%s/' % (RSYNC_PATH, PREFIX, version)
 
 for x, y in (
-        ("SOURCE_CODE", "artifacts/U-Track-@VERSION@.zip"),
-        ("DOC", "artifacts/U-Track-@VERSION@.pdf"),
+        ("SOURCE_CODE", "artifacts/u-track-@VERSION@.zip"),
+        ("DOC", "artifacts/u-track-@VERSION@.pdf"),
         ):
 
     find_pkg(repl, fingerprint_url, UTRACK_RSYNC_PATH, x, y, MD5s)

--- a/utrackgen.py
+++ b/utrackgen.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+import datetime
+import fileinput
+
+from doc_generator import find_pkg, repl_all
+
+fingerprint_url = "http://ci.openmicroscopy.org/fingerprint"
+
+
+def usage():
+    print "utrackgen.py version"
+    sys.exit(1)
+
+try:
+    version = sys.argv[1]
+except:
+    usage()
+
+repl = {"@VERSION@": version,
+        "@MONTHYEAR@": datetime.datetime.now().strftime("%b %Y")}
+
+MD5s = []
+
+
+RSYNC_PATH = os.environ.get('RSYNC_PATH', '/ome/data_repo/public/')
+PREFIX = os.environ.get('PREFIX', 'u-track')
+UTRACK_RSYNC_PATH = '%s/%s/%s/' % (RSYNC_PATH, PREFIX, version)
+
+for x, y in (
+        ("SOURCE_CODE", "artifacts/U-Track-@VERSION@.zip"),
+        ("DOC", "artifacts/U-Track-@VERSION@.pdf"),
+        ):
+
+    find_pkg(repl, fingerprint_url, UTRACK_RSYNC_PATH, x, y, MD5s)
+
+for line in fileinput.input(["utrack_downloads.html"]):
+    print repl_all(repl, line, check_http=True),


### PR DESCRIPTION
This is the same as gh-61 but rebased onto develop.

---

Similar to #58, this PR provides the framwork for generating a downloads page for the U-Track partner project. The corresponding jobs should be http://ci.openmicroscopy.org/view/Consortium/job/U-TRACK-release/? and http://ci.openmicroscopy.org/view/Consortium/job/U-TRACK-release-downloads.

/cc @hflynn 
