### PR TITLE
Remove the Windows builds from the downloads tables for 4.6.4 (rebased onto develop)

### DIFF
--- a/flimfit_downloads.html
+++ b/flimfit_downloads.html
@@ -70,12 +70,6 @@
         <th width="125">Checksum</th>
         </tr>
       <tr>
-        <td><a href="@FLIMFIT_50_WIN@"><img src="images/flimfit_win.png" alt="Windows Client Download" /></a></td>
-        <td align="center">@FLIMFIT_50_WIN_SIZE@</td>
-        <td>@FLIMFIT_50_WIN_BASE@</td>
-        <td align="center">@FLIMFIT_50_WIN_MD5@ (<a href="@FLIMFIT_50_WIN@.md5">MD5</a>)</td>
-      </tr>
-      <tr>
         <td><a href="@FLIMFIT_50_MAC@"><img src="images/flimfit_mac.png" alt="Mac OS X Client Download" /></a></td>
         <td align="center">@FLIMFIT_50_MAC_SIZE@</td>
         <td>@FLIMFIT_50_MAC_BASE@</td>
@@ -95,12 +89,6 @@
         <th width="271">File Name</th>
         <th width="125">Checksum</th>
         </tr>
-      <tr>
-        <td><a href="@FLIMFIT_44_WIN@"><img src="images/flimfit_win.png" alt="Windows Client Download" /></a></td>
-        <td align="center">@FLIMFIT_44_WIN_SIZE@</td>
-        <td>@FLIMFIT_44_WIN_BASE@</td>
-        <td align="center">@FLIMFIT_44_WIN_MD5@ (<a href="@FLIMFIT_44_WIN@.md5">MD5</a>)</td>
-      </tr>
       <tr>
         <td><a href="@FLIMFIT_44_MAC@"><img src="images/flimfit_mac.png" alt="Mac OS X Client Download" /></a></td>
         <td align="center">@FLIMFIT_44_MAC_SIZE@</td>


### PR DESCRIPTION
This is the same as gh-74 but rebased onto develop.

---

This commit will likely be reverted for upcoming versions of FLIMfit
once we sort out the Windows build.

/cc @hflynn @imunro
