### PR TITLE
Add  "use from source" text to FLIMfit downloads page. (rebased onto develop)

### DIFF
--- a/flimfit_downloads.html
+++ b/flimfit_downloads.html
@@ -38,7 +38,7 @@
 
 <div class="entry-content">
 
-<h2>FLIMFit @VERSION@ Downloads</h2>
+<h2>FLIMfit @VERSION@ Downloads</h2>
 
 <p>
   <strong><a href="#flimfit_50">OME 5.0</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#flimfit_44">OME 4.4</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#code">Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#legacy">Legacy</a> </strong></p>
@@ -60,13 +60,13 @@
 
 </li>
 <li>
-<p>Windows users please note that there is currently no pre-compiled binary of 4.6.4 for OME 5.0.x due to reported problems connecting to 5.0.0 servers from FLIMfit on some Windows variants. It is, however, possible to use FLIMfit from the MATLAB source on GitHub by following the link below.</p>
+<p>Windows users please note that there is currently no pre-compiled binary of 4.6.4 for OMERO 5.0.x due to reported problems connecting to 5.0.0 servers from FLIMfit on some Windows variants. It is, however, possible to use FLIMfit from the MATLAB source on GitHub by following the link below.</p>
 </li>
 </ul>
 
 
 
-<h2><a name="flimfit_50" id="flimfit_50"></a>FLIMFit downloads for OME 5.0.x</h2>
+<h2><a name="flimfit_50" id="flimfit_50"></a>FLIMfit downloads for OMERO 5.0.x</h2>
 <div class="alt-table">
   <table width="800" border="0" cellpadding="5">
     <tbody>
@@ -86,7 +86,7 @@
   </table>
 </div>
 
-<h2><a name="flimfit_44" id="flimfit_44"></a>FLIMFit downloads for OME 4.4.x</h2>
+<h2><a name="flimfit_44" id="flimfit_44"></a>FLIMfit downloads for OMERO 4.4.x</h2>
 <div class="alt-table">
   <table width="800" border="0" cellpadding="5">
     <tbody>
@@ -125,7 +125,7 @@
 
 <ul>
   <li>
-<p>We recommend that you always use the most recent release version of the FLIMFit software, but if you need to use a previous version,  they are all available from the main <a href="http://downloads.openmicroscopy.org/flimfit/?C=M;O=D">downloads folder</a></p>
+<p>We recommend that you always use the most recent release version of the FLIMfit software, but if you need to use a previous version,  they are all available from the main <a href="http://downloads.openmicroscopy.org/flimfit/?C=M;O=D">downloads folder</a></p>
   </li>
 </ul>
   

--- a/flimfit_downloads.html
+++ b/flimfit_downloads.html
@@ -60,7 +60,7 @@
 </ul>
 </li>
 <li>
-    <p>Windows users please note that there is currently no pre-compiled binary for OME 5.0.x due to reported problems connecting to 5.0.0 servers from FLIMfit on some Windows variants. It is, however, possible to use FLIMfit from the Matlab source.</p>
+<p>Windows users please note that there is currently no pre-compiled binary for OME 5.0.x due to reported problems connecting to 5.0.0 servers from FLIMfit on some Windows variants. It is, however, possible to use FLIMfit from the Matlab source by following the link below.</p>
 </li>
 </ul>
 

--- a/flimfit_downloads.html
+++ b/flimfit_downloads.html
@@ -58,6 +58,13 @@
 <p>Users who intend to use FLIMfit without OMERO can download either version (for 4.4.x or 5.0.x) as there will be no difference in stand-alone mode.</p>
 </li>
 </ul>
+</li>
+<li>
+    <p>Windows users please note that there is currently no pre-compiled binary for OME 5.0.x due to reported problems connecting to 5.0.0 servers from FLIMfit on some Windows variants. It is, however, possible to use FLIMfit from the Matlab source.</p>
+</li>
+</ul>
+
+
 
 <h2><a name="flimfit_50" id="flimfit_50"></a>FLIMFit downloads for OME 5.0.x</h2>
 <div class="alt-table">

--- a/flimfit_downloads.html
+++ b/flimfit_downloads.html
@@ -125,7 +125,7 @@
 
 <ul>
   <li>
-<p>We recommend that you always use the most recent release version of the FLIMfit software, but if you need to use a previous version,  they are all available from the main <a href="http://downloads.openmicroscopy.org/flimfit/?C=M;O=D">downloads folder</a></p>
+<p>We recommend that you always use the most recent release version of the FLIMfit software, but if you need to use a previous version,  they are all available from the main <a href="http://downloads.openmicroscopy.org/flimfit/?C=M;O=D">downloads folder</a>.</p>
   </li>
 </ul>
   

--- a/flimfit_downloads.html
+++ b/flimfit_downloads.html
@@ -41,7 +41,7 @@
 <h2>FLIMfit @VERSION@ Downloads</h2>
 
 <p>
-  <strong><a href="#flimfit_50">OME 5.0</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#flimfit_44">OME 4.4</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#code">Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#legacy">Legacy</a> </strong></p>
+  <strong><a href="#flimfit_50">OMERO 5.0</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#flimfit_44">OMERO 4.4</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#code">Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#legacy">Legacy</a> </strong></p>
 
 <ul>
 <li>

--- a/flimfit_downloads.html
+++ b/flimfit_downloads.html
@@ -57,10 +57,10 @@
 <li>
 <p>Users who intend to use FLIMfit without OMERO can download either version (for 4.4.x or 5.0.x) as there will be no difference in stand-alone mode.</p>
 </li>
-</ul>
+
 </li>
 <li>
-<p>Windows users please note that there is currently no pre-compiled binary for OME 5.0.x due to reported problems connecting to 5.0.0 servers from FLIMfit on some Windows variants. It is, however, possible to use FLIMfit from the Matlab source by following the link below.</p>
+<p>Windows users please note that there is currently no pre-compiled binary of 4.6.4 for OME 5.0.x due to reported problems connecting to 5.0.0 servers from FLIMfit on some Windows variants. It is, however, possible to use FLIMfit from the MATLAB source on GitHub by following the link below.</p>
 </li>
 </ul>
 


### PR DESCRIPTION
This is the same as gh-78 but rebased onto develop.

---
