### PR TITLE
Change legacy to previous versions (rebased onto develop)

### DIFF
--- a/bf_downloads.html
+++ b/bf_downloads.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-        
+
         <link rel="stylesheet" href="images/plonematch.css" type="text/css">
         <meta charset="utf-8">
-          
-  
+
+
       <meta name="tags" contents="bio-formats">
       <meta name="tags" contents="downloads">
-  
+
     <style type="text/css"></style><style>[touch-action="none"]{ -ms-touch-action: none; touch-action: none; }[touch-action="pan-x"]{ -ms-touch-action: pan-x; touch-action: pan-x; }[touch-action="pan-y"]{ -ms-touch-action: pan-y; touch-action: pan-y; }[touch-action="scroll"],[touch-action="pan-x pan-y"],[touch-action="pan-y pan-x"]{ -ms-touch-action: pan-x pan-y; touch-action: pan-x pan-y; }</style></head>
     <body id="index" class="home">
 
@@ -42,7 +42,7 @@
 <h2>Bio-Formats @VERSION@ Downloads</h2>
 
 <p>
-  <strong><a href="#tools">Tools</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#api">API</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#components">Components</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#code">Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#legacy">Legacy</a> </strong></p>
+  <strong><a href="#tools">Tools</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#api">API</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#components">Components</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#code">Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#previous">Previous versions</a> </strong></p>
 
 <ul>
 <li>
@@ -279,14 +279,14 @@
 </table>
 </div>
 
-<h2><a name="legacy" id="legacy"></a>Legacy versions</h2>
+<h2><a name="previous" id="previous"></a>Previous versions</h2>
 
 <ul>
   <li>
 <p>Previous versions of Bio-Formats can be found on the <a href="http://downloads.openmicroscopy.org/bio-formats/?C=M;O=D">Bio-Formats archive</a> page.</p>
   </li>
 </ul>
-  
+
   </div><!-- /.entry-content -->
 </section>
         <footer id="contentinfo" class="body">
@@ -306,5 +306,5 @@
 		</div>
 		<div class="visualClear">
 		<!-- OME Footer - END -->
-	
+
 </div></div></body></html>

--- a/flimfit_downloads.html
+++ b/flimfit_downloads.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-        
+
         <link rel="stylesheet" href="images/plonematch.css" type="text/css">
         <meta charset="utf-8">
-          
-  
+
+
       <meta name="tags" contents="flimfit">
-  
+
     <style type="text/css"></style><style>[touch-action="none"]{ -ms-touch-action: none; touch-action: none; }[touch-action="pan-x"]{ -ms-touch-action: pan-x; touch-action: pan-x; }[touch-action="pan-y"]{ -ms-touch-action: pan-y; touch-action: pan-y; }[touch-action="scroll"],[touch-action="pan-x pan-y"],[touch-action="pan-y pan-x"]{ -ms-touch-action: pan-x pan-y; touch-action: pan-x pan-y; }</style></head>
     <body id="index" class="home">
 
@@ -41,7 +41,7 @@
 <h2>FLIMfit @VERSION@ Downloads</h2>
 
 <p>
-  <strong><a href="#flimfit_50">OMERO 5.0</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#flimfit_44">OMERO 4.4</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#code">Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#legacy">Legacy</a> </strong></p>
+  <strong><a href="#flimfit_50">OMERO 5.0</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#flimfit_44">OMERO 4.4</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#code">Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#previous">Previous versions</a> </strong></p>
 
 <ul>
 <li>
@@ -121,14 +121,14 @@
 </table>
 </div>
 
-<h2><a name="legacy" id="legacy"></a>Legacy versions</h2>
+<h2><a name="previous" id="previous"></a>Previous versions</h2>
 
 <ul>
   <li>
 <p>We recommend that you always use the most recent release version of the FLIMfit software, but if you need to use a previous version,  they are all available from the main <a href="http://downloads.openmicroscopy.org/flimfit/?C=M;O=D">downloads folder</a>.</p>
   </li>
 </ul>
-  
+
   </div><!-- /.entry-content -->
 </section>
         <footer id="contentinfo" class="body">
@@ -148,5 +148,5 @@
 		</div>
 		<div class="visualClear">
 		<!-- OME Footer - END -->
-	
+
 </div></div></body></html>

--- a/omero_downloads.html
+++ b/omero_downloads.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-        
+
         <link rel="stylesheet" href="images/plonematch.css" type="text/css">
         <meta charset="utf-8">
-          
-  
+
+
       <meta name="tags" contents="omero">
       <meta name="tags" contents="downloads">
-  
+
     <style type="text/css"></style><style>[touch-action="none"]{ -ms-touch-action: none; touch-action: none; }[touch-action="pan-x"]{ -ms-touch-action: pan-x; touch-action: pan-x; }[touch-action="pan-y"]{ -ms-touch-action: pan-y; touch-action: pan-y; }[touch-action="scroll"],[touch-action="pan-x pan-y"],[touch-action="pan-y pan-x"]{ -ms-touch-action: pan-x pan-y; touch-action: pan-x pan-y; }</style></head>
     <body id="index" class="home">
 
@@ -42,7 +42,7 @@
 <h2>OMERO @VERSION@ Downloads</h2>
 
 <p>
-  <strong><a href="#clients">Clients</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#plugins">Plugins</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#additional">Additional</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#servers">Servers</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#va">Virtual Appliance</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#api">API</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#code">Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#components">Components</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#legacy">Legacy</a> </strong></p>
+  <strong><a href="#clients">Clients</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#plugins">Plugins</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#additional">Additional</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#servers">Servers</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#va">Virtual Appliance</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#api">API</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#code">Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#components">Components</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#previous">Previous versions</a> </strong></p>
 
 <ul>
 <li>
@@ -97,10 +97,10 @@ clients with the 5.0 server</p>
 
 <ul>
 <li>
-<p>Each client package includes 
-<a href="@DOC_URL@/users/clients-overview.html#omero-insight">OMERO.insight</a>, 
-<a href="@DOC_URL@/users/clients-overview.html#omero-importer">OMERO.importer</a> and 
-<a href="@DOC_URL@/users/clients-overview.html#omero-editor">OMERO.editor</a> and requires 
+<p>Each client package includes
+<a href="@DOC_URL@/users/clients-overview.html#omero-insight">OMERO.insight</a>,
+<a href="@DOC_URL@/users/clients-overview.html#omero-importer">OMERO.importer</a> and
+<a href="@DOC_URL@/users/clients-overview.html#omero-editor">OMERO.editor</a> and requires
 Java Version <strong>1.6</strong> or higher. OMERO.web is part of the server package, so individual users do not need to install it locally.</p>
 </li>
 <li>
@@ -199,8 +199,8 @@ Java Version <strong>1.6</strong> or higher. OMERO.web is part of the server pac
   should work with any version of the server)</p>
 </li>
 <li>
-<p>Installation instructions are available for: <a href="@DOC_URL@/sysadmins/unix/server-installation.html">Unix  
-platforms</a>, <a href="@DOC_URL@/sysadmins/windows/server-installation.html">Microsoft 
+<p>Installation instructions are available for: <a href="@DOC_URL@/sysadmins/unix/server-installation.html">Unix
+platforms</a>, <a href="@DOC_URL@/sysadmins/windows/server-installation.html">Microsoft
 Windows</a> </p>
 </li>
 <li>
@@ -320,14 +320,14 @@ Windows</a> </p>
   </li>
 </ul>
 
-<h2><a name="legacy" id="legacy"></a>Legacy versions</h2>
+<h2><a name="previous" id="previous"></a>Previous versions</h2>
 
 <ul>
   <li>
 <p>We recommend that you always use the most recent release version of the OMERO software, but if you need to use a previous version,  they are all available from the main <a href="http://downloads.openmicroscopy.org/omero/?C=M;O=D">downloads folder</a></p>
   </li>
 </ul>
-  
+
   </div><!-- /.entry-content -->
 </section>
         <footer id="contentinfo" class="body">
@@ -347,5 +347,5 @@ Windows</a> </p>
 		</div>
 		<div class="visualClear">
 		<!-- OME Footer - END -->
-	
+
 </div></div></body></html>


### PR DESCRIPTION
This is the same as gh-88 but rebased onto develop.

---

The download pages currently use 'legacy' to indicate previous versions - this is both inconsistent with elsewhere on om.org where we use legacy to mean something broader (e.g. covering the OME server), and confusing to users as pointed out by Graeme Ball. This PR changes all the download pages which have these sections to use 'previous versions' instead as this has a clear meaning to users.

To be rebased to dev_4_4 and develop.
