### PR TITLE
Add new JAR to Bio-Formats downloads page (rebased onto dev_4_4)

### DIFF
--- a/bf_downloads.html
+++ b/bf_downloads.html
@@ -42,14 +42,11 @@
 <h2>Bio-Formats @VERSION@ Downloads</h2>
 
 <p>
-  <strong><a href="#tools">Tools</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#components">Components</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#code">Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#legacy">Legacy</a> </strong></p>
+  <strong><a href="#tools">Tools</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#api">API</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#components">Components</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#code">Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#legacy">Legacy</a> </strong></p>
 
 <ul>
 <li>
 <p>Full documentation is available as <a href="@DOC_URL@">web documentation</a> or <a href="@DOC@">PDF documentation</a>.</p>
-</li>
-<li>
-<p>The Bio-Formats API documentation is available to read on the web <a href="api">here</a>.</p>
 </li>
 <li>
 <p>Internet Explorer sometimes renames JAR files to ZIP (e.g., loci_tools.jar becomes loci_tools.zip); if this happens to you, simply rename the file back to its original name after the download is complete.</p>
@@ -104,6 +101,33 @@
 <li>
 <p>@MATLAB_TOOLS_BASE@ is a bundle of functions for using Bio-Formats from MATLAB.</p>
 </li>
+</ul>
+
+
+<h2><a name="api" id="api"></a>Bio-Formats API documentation</h2>
+<div class="alt-table">
+<table width="800" border="0" cellpadding="5">
+  <tbody>
+    <tr>
+      <th width="269">API Documentation</th>
+      <th width="85">Size</th>
+      <th width="150">File Name</th>
+      <th width="125">MD5 Checksum</th>
+    </tr>
+    <tr>
+      <td><a href="@JAVADOCS@"><img src="images/api_download.png" alt="API Documentation Download" /></a></td>
+      <td align="center">@JAVADOCS_SIZE@</td>
+      <td>@JAVADOCS_BASE@</td>
+      <td align="center">@JAVADOCS_MD5@ (<a href="@DOCS@.md5">MD5</a>)</td>
+      </tr>
+  </tbody>
+</table>
+</div>
+
+<ul>
+  <li>
+  <p>The Bio-Formtats API documentation is also available to read on the web <a href="api">here</a></p>
+  </li>
 </ul>
 
 <h2><a name="components" id="components"></a>Bio-Formats components downloads</h2>

--- a/bf_downloads.html
+++ b/bf_downloads.html
@@ -126,7 +126,7 @@
 
 <ul>
   <li>
-  <p>The Bio-Formtats API documentation is also available to read on the web <a href="api">here</a></p>
+  <p>The Bio-Formats API documentation is also available to read on the web <a href="api">here</a></p>
   </li>
 </ul>
 

--- a/bf_downloads.html
+++ b/bf_downloads.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-        
+
         <link rel="stylesheet" href="images/plonematch.css" type="text/css">
         <meta charset="utf-8">
-          
-  
+
+
       <meta name="tags" contents="bio-formats">
       <meta name="tags" contents="downloads">
-  
+
     <style type="text/css"></style><style>[touch-action="none"]{ -ms-touch-action: none; touch-action: none; }[touch-action="pan-x"]{ -ms-touch-action: pan-x; touch-action: pan-x; }[touch-action="pan-y"]{ -ms-touch-action: pan-y; touch-action: pan-y; }[touch-action="scroll"],[touch-action="pan-x pan-y"],[touch-action="pan-y pan-x"]{ -ms-touch-action: pan-x pan-y; touch-action: pan-x pan-y; }</style></head>
     <body id="index" class="home">
 
@@ -42,7 +42,7 @@
 <h2>Bio-Formats @VERSION@ Downloads</h2>
 
 <p>
-  <strong><a href="#tools">Tools</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#api">API</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#components">Components</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#code">Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#legacy">Legacy</a> </strong></p>
+  <strong><a href="#tools">Tools</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#api">API</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#components">Components</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#code">Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#previous">Previous versions</a> </strong></p>
 
 <ul>
 <li>
@@ -268,14 +268,14 @@
 </table>
 </div>
 
-<h2><a name="legacy" id="legacy"></a>Legacy versions</h2>
+<h2><a name="previous" id="previous"></a>Previous versions</h2>
 
 <ul>
   <li>
 <p>Previous versions of Bio-Formats can be found on the <a href="http://downloads.openmicroscopy.org/bio-formats/?C=M;O=D">Bio-Formats archive</a> page.</p>
   </li>
 </ul>
-  
+
   </div><!-- /.entry-content -->
 </section>
         <footer id="contentinfo" class="body">
@@ -295,5 +295,5 @@
 		</div>
 		<div class="visualClear">
 		<!-- OME Footer - END -->
-	
+
 </div></div></body></html>

--- a/bfgen.py
+++ b/bfgen.py
@@ -77,6 +77,7 @@ for x, y in (
         ("ome_plugins.jar", "artifacts/ome_plugins.jar"),
         ("ome-editor.jar", "artifacts/ome-editor.jar"),
         ("poi-loci.jar", "artifacts/poi-loci.jar"),
+        ("JAVADOCS", "artifacts/bio-formats-javadocs.zip"),
         ("jai_imageio.jar", "artifacts/jai_imageio.jar"),
         ("lwf-stubs.jar", "artifacts/lwf-stubs.jar"),
         ("mdbtools-java.jar", "artifacts/mdbtools-java.jar"),

--- a/omero_downloads.html
+++ b/omero_downloads.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-        
+
         <link rel="stylesheet" href="images/plonematch.css" type="text/css">
         <meta charset="utf-8">
-          
-  
+
+
       <meta name="tags" contents="omero">
       <meta name="tags" contents="downloads">
-  
+
     <style type="text/css"></style><style>[touch-action="none"]{ -ms-touch-action: none; touch-action: none; }[touch-action="pan-x"]{ -ms-touch-action: pan-x; touch-action: pan-x; }[touch-action="pan-y"]{ -ms-touch-action: pan-y; touch-action: pan-y; }[touch-action="scroll"],[touch-action="pan-x pan-y"],[touch-action="pan-y pan-x"]{ -ms-touch-action: pan-x pan-y; touch-action: pan-x pan-y; }</style></head>
     <body id="index" class="home">
 
@@ -42,7 +42,7 @@
 <h2>OMERO @VERSION@ Downloads</h2>
 
 <p>
-  <strong><a href="#clients">Clients</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#plugins">Plugins</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#additional">Additional</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#servers">Servers</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#va">Virtual Appliance</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#api">API</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#code">Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#components">Components</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#legacy">Legacy</a> </strong></p>
+  <strong><a href="#clients">Clients</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#plugins">Plugins</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#additional">Additional</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#servers">Servers</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#va">Virtual Appliance</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#api">API</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#code">Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#components">Components</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#previous">Previous versions</a> </strong></p>
 
 <ul>
 <li>
@@ -94,10 +94,10 @@ clients with the 4.4 server</p>
 
 <ul>
 <li>
-<p>Each client package includes 
-<a href="@DOC_URL@/users/clients-overview.html#omero-insight">OMERO.insight</a>, 
-<a href="@DOC_URL@/users/clients-overview.html#omero-importer">OMERO.importer</a> and 
-<a href="@DOC_URL@/users/clients-overview.html#omero-editor">OMERO.editor</a> and requires 
+<p>Each client package includes
+<a href="@DOC_URL@/users/clients-overview.html#omero-insight">OMERO.insight</a>,
+<a href="@DOC_URL@/users/clients-overview.html#omero-importer">OMERO.importer</a> and
+<a href="@DOC_URL@/users/clients-overview.html#omero-editor">OMERO.editor</a> and requires
 Java Version <strong>1.6</strong> or higher. OMERO.web is part of the server package, so individual users do not need to install it locally.</p>
 </li>
 <li>
@@ -196,8 +196,8 @@ Java Version <strong>1.6</strong> or higher. OMERO.web is part of the server pac
   should work with any version of the server)</p>
 </li>
 <li>
-<p>Installation instructions are available for: <a href="@DOC_URL@/sysadmins/unix/server-installation.html">Unix  
-platforms</a>, <a href="@DOC_URL@/sysadmins/windows/server-installation.html">Microsoft 
+<p>Installation instructions are available for: <a href="@DOC_URL@/sysadmins/unix/server-installation.html">Unix
+platforms</a>, <a href="@DOC_URL@/sysadmins/windows/server-installation.html">Microsoft
 Windows</a> </p>
 </li>
 <li>
@@ -298,14 +298,14 @@ Windows</a> </p>
   </li>
 </ul>
 
-<h2><a name="legacy" id="legacy"></a>Legacy versions</h2>
+<h2><a name="previous" id="previous"></a>Previous versions</h2>
 
 <ul>
   <li>
 <p>We recommend that you always use the most recent release version of the OMERO software, but if you need to use a previous version,  they are all available from the main <a href="http://downloads.openmicroscopy.org/omero/?C=M;O=D">downloads folder</a></p>
   </li>
 </ul>
-  
+
   </div><!-- /.entry-content -->
 </section>
         <footer id="contentinfo" class="body">


### PR DESCRIPTION
This is the same as gh-47 but rebased onto dev_4_4.

---

This PR:
- adds the new `bioformats_package.jar` to the principal downloads table 
- replaces the Bio-Formats icons used the new ones designed by @gusferguson
- adds the zipped API documentation to the downloads page

Closes #37
