### PR TITLE
Validate and tidy html files (rebased onto develop)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,9 @@ virtualenv:
 before_install:
   - pip install -r requirements.txt
   - pip install flake8
+  - wget http://tidy.sourceforge.net/trt/tidy_mklinux.tgz
+  - tar -zxvf tidy_mklinux.tgz
 
-script: flake8 -v *.py
+script:
+  - flake8 -v *.py
+  - tidy omero_downloads.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ before_install:
 
 script:
   - flake8 -v *.py
-  - tidy *.html
+  - tidy -e *.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,8 @@ virtualenv:
 before_install:
   - pip install -r requirements.txt
   - pip install flake8
-  - wget http://tidy.sourceforge.net/trt/tidy_mklinux.tgz
-  - tar -zxvf tidy_mklinux.tgz
+  - sudo apt-get install tidy
 
 script:
-  - ls
   - flake8 -v *.py
   - tidy omero_downloads.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,6 @@ before_install:
   - tar -zxvf tidy_mklinux.tgz
 
 script:
+  - ls
   - flake8 -v *.py
   - tidy omero_downloads.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ before_install:
 
 script:
   - flake8 -v *.py
-  - tidy omero_downloads.html
+  - tidy *.html

--- a/bf_downloads.html
+++ b/bf_downloads.html
@@ -1,310 +1,365 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 
-        <link rel="stylesheet" href="images/plonematch.css" type="text/css">
-        <meta charset="utf-8">
-
-
-      <meta name="tags" contents="bio-formats">
-      <meta name="tags" contents="downloads">
-
-    <style type="text/css"></style><style>[touch-action="none"]{ -ms-touch-action: none; touch-action: none; }[touch-action="pan-x"]{ -ms-touch-action: pan-x; touch-action: pan-x; }[touch-action="pan-y"]{ -ms-touch-action: pan-y; touch-action: pan-y; }[touch-action="scroll"],[touch-action="pan-x pan-y"],[touch-action="pan-y pan-x"]{ -ms-touch-action: pan-x pan-y; touch-action: pan-x pan-y; }</style></head>
-    <body id="index" class="home">
-
+		<link rel="stylesheet" href="images/plonematch.css" type="text/css" />
+		<style type="text/css">
+			[touch-action = "none"]{
+				-ms-touch-action:none;
+				touch-action:none;
+			}
+			[touch-action = "pan-x"]{
+				-ms-touch-action:pan-x;
+				touch-action:pan-x;
+			}
+			[touch-action = "pan-y"]{
+				-ms-touch-action:pan-y;
+				touch-action:pan-y;
+			}
+			[touch-action = "scroll"],
+			[touch-action = "pan-x pan-y"],
+			[touch-action = "pan-y pan-x"]{
+				-ms-touch-action:pan-x pan-y;
+				touch-action:pan-x pan-y;
+			}</style>
+		<title></title>
+	</head>
+	<body id="index" class="home">
 		<!-- OME Banner - START -->
 		<div id="portal-top">
 			<div id="portal-header">
 				<ul id="portal-siteactions">
 					<li>
-						<br>
+						<br />
 					</li>
-				</ul><a id="portal-logo" accesskey="1" href="http://downloads.openmicroscopy.org/" name="portal-logo"><img src="images/logo.jpg" alt="" title="" height="73" width="450"></a>
-			  <div id="portal-globalnav">
-					<br>
+				</ul><a id="portal-logo" accesskey="1" href="http://downloads.openmicroscopy.org/"
+					name="portal-logo"><img src="images/logo.jpg" alt="" title="" height="73"
+						width="450" /></a>
+				<div id="portal-globalnav">
+					<br />
 				</div>
 			</div>
 			<div id="portal-personaltools-wrapper">
 				<ul id="portal-personaltools" class="visualInline">
 					<li>
-						<br>
+						<br />
 					</li>
 				</ul>
 			</div>
 		</div>
 		<div class="visualClear" id="clear-space-before-wrapper-table">
-		<!-- OME Banner - END -->
-
-                                  <!-- /#menu -->
-<section id="content" class="body" style="margin-left:20px;">
-
-<div class="entry-content">
-
-<h2>Bio-Formats @VERSION@ Downloads</h2>
-
-<p>
-  <strong><a href="#tools">Tools</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#api">API</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#components">Components</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#code">Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#previous">Previous versions</a> </strong></p>
-
-<ul>
-<li>
-<p>Full documentation is available as <a href="@DOC_URL@">web documentation</a> or <a href="@DOC@">PDF documentation</a>.</p>
-</li>
-<li>
-<p>Internet Explorer sometimes renames JAR files to ZIP (e.g., bioformats_package.jar becomes bioformats_package.zip); if this happens to you, simply rename the file back to its original name after the download is complete.</p>
-</li>
-<li>
-<p>For some browsers, you may need to right-click or control-click the link and choose "Save link as..." or a similar option to download the file.</p>
-</li>
-</ul>
-
-
-<h2><a name="tools" id="tools"></a>Bio-Formats tools downloads</h2>
-
-<div class="alt-table">
-  <table width="800" border="0" cellpadding="5">
-    <tbody>
-      <tr>
-        <th width="269">Clients</th>
-        <th width="85">Size</th>
-        <th width="150">File Name</th>
-        <th width="125">Checksum</th>
-      </tr>
-      <tr>
-        <td><a href="@bioformats_package.jar@"><img src="images/bf_package.png" alt="Bio-Formats Package" /></a></td>
-        <td align="center">@bioformats_package.jar_SIZE@</td>
-        <td>@bioformats_package.jar_BASE@</td>
-        <td align="center">@bioformats_package.jar_MD5@ (<a href="@bioformats_package.jar@.md5">MD5</a>)</td>
-      </tr>
-      <tr>
-        <td><a href="@COMMAND_LINE_TOOLS@"><img src="images/bf_cm_tools.png" alt="Command Line Tools" /></a></td>
-        <td align="center">@COMMAND_LINE_TOOLS_SIZE@</td>
-        <td>@COMMAND_LINE_TOOLS_BASE@</td>
-        <td align="center">@COMMAND_LINE_TOOLS_MD5@ (<a href="@COMMAND_LINE_TOOLS@.md5">MD5</a>)</td>
-      </tr>
-      <tr>
-        <td><a href="@MATLAB_TOOLS@"><img src="images/bf_matlab_toolbox.png" alt="MATLAB Toolbox" /></a></td>
-        <td align="center">@MATLAB_TOOLS_SIZE@</td>
-        <td>@MATLAB_TOOLS_BASE@</td>
-        <td align="center">@MATLAB_TOOLS_MD5@ (<a href="@MATLAB_TOOLS@.md5">MD5</a>)</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-
-<ul>
-<li>
-<p>@bioformats_package.jar_BASE@ is the complete bundle (for end users) containing everything needed to read images into ImageJ using Bio-Formats. Instructions for installing Bio-Formats in ImageJ are available in the
-<a href="@DOC_URL@/users/imagej/installing.html">user guide</a>.</p>
-</li>
-<li>
-<p>@COMMAND_LINE_TOOLS_BASE@ is a bundle of scripts for using Bio-Formats on the command line <b>now with bioformats_package.jar included so you do not have to install both separately</b>. See the <a href="@DOC_URL@/users/comlinetools/index.html">command line tools documentation</a> for further information.</p>
-</li>
-<li>
-<p>@MATLAB_TOOLS_BASE@ is a bundle of functions for using Bio-Formats from MATLAB <b>now with bioformats_package.jar included so you do not have to install both separately</b>. See the <a href="@DOC_URL@/users/matlab/index.html">MATLAB documentation</a> for further information.</p>
-</li>
-</ul>
-
-
-<h2><a name="api" id="api"></a>Bio-Formats API documentation</h2>
-<div class="alt-table">
-<table width="800" border="0" cellpadding="5">
-  <tbody>
-    <tr>
-      <th width="269">API Documentation</th>
-      <th width="85">Size</th>
-      <th width="150">File Name</th>
-      <th width="125">MD5 Checksum</th>
-    </tr>
-    <tr>
-      <td><a href="@JAVADOCS@"><img src="images/api_download.png" alt="API Documentation Download" /></a></td>
-      <td align="center">@JAVADOCS_SIZE@</td>
-      <td>@JAVADOCS_BASE@</td>
-      <td align="center">@JAVADOCS_MD5@ (<a href="@DOCS@.md5">MD5</a>)</td>
-      </tr>
-  </tbody>
-</table>
-</div>
-
-<ul>
-  <li>
-  <p>The Bio-Formats API documentation is also available to read on the web <a href="api">here</a></p>
-  </li>
-</ul>
-
-<h2><a name="components" id="components"></a>Bio-Formats components downloads</h2>
-
-<div class="alt-table">
-  <table width="800" border="0" cellpadding="5">
-    <tbody>
-      <tr>
-        <th width="180">Project</th>
-        <th width="150">@VERSION@</th>
-        <th width="150">Latest build</th>
-        <th width="150">Daily build</th>
-        </tr>
-	<tr>
-		<th align="center"colspan="4">Packages</th>
-	</tr>
-	<tr>
-		<td>Bio-Formats package</td>
-		<td><a href="@bioformats_package.jar@">bioformats_package.jar</a></td>
-		<td><a href="@LATEST_bioformats_package.jar@">bioformats_package.jar</a></td>
-		<td><a href="@DAILY_bioformats_package.jar@">bioformats_package.jar</a></td>
-	</tr>
-	<tr>
-		<td>LOCI Tools</td>
-		<td><a href="@loci_tools.jar@">loci_tools.jar</a></td>
-		<td><a href="@LATEST_loci_tools.jar@">loci_tools.jar</a></td>
-		<td><a href="@DAILY_loci_tools.jar@">loci_tools.jar</a></td>
-	</tr>
-	<tr>
-		<th align="center"colspan="4">Core</th>
-	</tr>
-	<tr>
-		<td>Bio-Formats API library</td>
-		<td><a href="@formats-api.jar@">formats-api.jar</a></td>
-		<td><a href="@LATEST_formats-api.jar@">formats-api.jar</a></td>
-		<td><a href="@DAILY_formats-api.jar@">formats-api.jar</a></td>
-	</tr>
-	<tr>
-		<td>Bio-Formats BSD library</td>
-		<td><a href="@formats-bsd.jar@">formats-bsd.jar</a></td>
-		<td><a href="@LATEST_formats-bsd.jar@">formats-bsd.jar</a></td>
-		<td><a href="@DAILY_formats-bsd.jar@">formats-bsd.jar</a></td>
-	</tr>
-	<tr>
-		<td>Bio-Formats Common library</td>
-		<td><a href="@formats-common.jar@">formats-common.jar</a></td>
-		<td><a href="@LATEST_formats-common.jar@">formats-common.jar</a></td>
-		<td><a href="@DAILY_formats-common.jar@">formats-common.jar</a></td>
-	</tr>
-	<tr>
-		<td>Bio-Formats GPL library</td>
-		<td><a href="@formats-gpl.jar@">formats-gpl.jar</a></td>
-		<td><a href="@LATEST_formats-gpl.jar@">formats-gpl.jar</a></td>
-		<td><a href="@DAILY_formats-gpl.jar@">formats-gpl.jar</a></td>
-	</tr>
-	<tr>
-		<td>Bio-Formats BSD Test library</td>
-		<td><a href="@formats-bsd-test.jar@">formats-bsd-test.jar</a></td>
-		<td><a href="@LATEST_formats-bsd-test.jar@">formats-bsd-test.jar</a></td>
-		<td><a href="@DAILY_formats-bsd-test.jar@">formats-bsd-test.jar</a></td>
-	</tr>
-	<tr>
-		<td>OME-XML Java library</td>
-		<td><a href="@ome-xml.jar@">ome-xml.jar</a></td>
-		<td><a href="@LATEST_ome-xml.jar@">ome-xml.jar</a></td>
-		<td><a href="@DAILY_ome-xml.jar@">ome-xml.jar</a></td>
-	</tr>
-	<tr>
-		<td>OME Model Specification</td>
-		<td><a href="@specification.jar@">specification.jar</a></td>
-		<td><a href="@LATEST_specification.jar@">specification.jar</a></td>
-		<td><a href="@DAILY_specification.jar@">specification.jar</a></td>
-	</tr>
-	<tr>
-		<td>Bio-Formats Plugins for ImageJ</td>
-		<td><a href="@bio-formats_plugins.jar@">bio-formats_plugins.jar</a></td>
-		<td><a href="@LATEST_bio-formats_plugins.jar@">bio-formats_plugins.jar</a></td>
-		<td><a href="@DAILY_bio-formats_plugins.jar@">bio-formats_plugins.jar</a></td>
-	</tr>
-	<tr>
-		<td>Metakit</td>
-		<td><a href="@metakit.jar@">metakit.jar</a></td>
-		<td><a href="@LATEST_metakit.jar@">metakit.jar</a></td>
-		<td><a href="@DAILY_metakit.jar@">metakit.jar</a></td>
-	</tr>
-	<tr>
-	<td>Bio-Formats testing framework</td>
-		<td><a href="@bio-formats-testing-framework.jar@">bio-formats-testing-framework.jar</a></td>
-		<td><a href="@LATEST_bio-formats-testing-framework.jar@">bio-formats-testing-framework.jar</a></td>
-		<td><a href="@DAILY_bio-formats-testing-framework.jar@">bio-formats-testing-framework.jar</a></td>
-	</tr>
-	<tr>
-		<th align="center" colspan="4">Forks</th>
-	</tr>
-	<tr>
-		<td>JAI Image I/O Tools</td>
-		<td><a href="@jai_imageio.jar@">jai_imageio.jar</a></td>
-		<td><a href="@LATEST_jai_imageio.jar@">jai_imageio.jar</a></td>
-		<td><a href="@DAILY_jai_imageio.jar@">jai_imageio.jar</a></td>
-	</tr>
-	<tr>
-		<td>MDB Tools (Java port)</td>
-		<td><a href="@mdbtools-java.jar@">mdbtools-java.jar</a></td>
-		<td><a href="@LATEST_mdbtools-java.jar@">mdbtools-java.jar</a></td>
-		<td><a href="@DAILY_mdbtools-java.jar@">mdbtools-java.jar</a></td>
-	</tr>
-	<tr>
-		<td>Apache Jakarta POI</td>
-		<td><a href="@ome-poi.jar@">ome-poi.jar</a></td>
-		<td><a href="@LATEST_ome-poi.jar@">ome-poi.jar</a></td>
-		<td><a href="@DAILY_ome-poi.jar@">ome-poi.jar</a></td>
-	</tr>
-	<tr>
-		<td>TurboJPEG</td>
-		<td><a href="@turbojpeg.jar@">turbojpeg.jar</a></td>
-		<td><a href="@LATEST_turbojpeg.jar@">turbojpeg.jar</a></td>
-		<td><a href="@DAILY_turbojpeg.jar@">turbojpeg.jar</a></td>
-	</tr>
-	<tr>
-		<th align="center" colspan="4">Stubs</th>
-	</tr>
-	<tr>
-		<td>Luratech LuraWave stubs</td>
-		<td><a href="@lwf-stubs.jar@">lwf-stubs.jar</a></td>
-		<td><a href="@LATEST_lwf-stubs.jar@">lwf-stubs.jar</a></td>
-		<td><a href="@DAILY_lwf-stubs.jar@">lwf-stubs.jar</a></td>
-	</tr>
-	</table>
-</div>
-
-<h2><a name="code" id="code"></a>Source code</h2>
-
-<div class="alt-table">
-<table width="278" border="0" cellpadding="5">
-  <tbody>
-    <tr>
-      <th width="264">Source Code</th>
-      </tr>
-    <tr>
-      <td><a href="http://github.com/openmicroscopy/bioformats" target="_blank"><img src="images/github_rep_link.png" alt="GitHub Repository Link" /></a></td>
-      </tr>
-    <tr>
-      <td><a href="http://git.openmicroscopy.org/" target="_blank"><img src="images/gitweb_int_link.png" alt="Gitweb Interface Link" /></a></td>
-     </tr>
-    <tr>
-      <td><a href="@TAG_URL@" target="_blank"><img src="images/git_tag.png" alt="GitHub Tag" /></a></td>
-    </tr>
-  </tbody>
-</table>
-</div>
-
-<h2><a name="previous" id="previous"></a>Previous versions</h2>
-
-<ul>
-  <li>
-<p>Previous versions of Bio-Formats can be found on the <a href="http://downloads.openmicroscopy.org/bio-formats/?C=M;O=D">Bio-Formats archive</a> page.</p>
-  </li>
-</ul>
-
-  </div><!-- /.entry-content -->
-</section>
-        <footer id="contentinfo" class="body">
-        </footer><!-- /#contentinfo -->
-
-		<!-- OME Footer - Start -->
-		<div class="visualClear" id="clear-space-before-footer"><!-- --></div>
-		<div id="portal-footer">
-			<p>
-				<acronym title="Copyright">&copy;</acronym>
-				2000-2014
-				University of Dundee &amp; Open Microscopy Environment. <a href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing">Creative Commons Attribution 3.0 Unported License</a>
-			</p>
-			<p>
-				OME source code is available under the <a href="http://www.openmicroscopy.org/site/about/licensing">GNU General public license</a> or through commercial license from <a href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software">Glencoe Software</a>
-			</p>
+			<!-- OME Banner - END -->
+			<!-- /#menu -->
+			<!-- <section id="content" class="body" style="margin-left:20px;"> -->
+			<div class="entry-content">
+				<h2>Bio-Formats @VERSION@ Downloads</h2>
+				<p>
+					<strong><a href="#tools">Tools</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#api"
+							>API</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#components"
+							>Components</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#code"
+							>Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#previous">Previous
+							versions</a>
+					</strong></p>
+				<ul>
+					<li>
+						<p>Full documentation is available as <a href="@DOC_URL@">web
+								documentation</a> or <a href="@DOC@">PDF documentation</a>.</p>
+					</li>
+					<li>
+						<p>Internet Explorer sometimes renames JAR files to ZIP (e.g.,
+							bioformats_package.jar becomes bioformats_package.zip); if this happens
+							to you, simply rename the file back to its original name after the
+							download is complete.</p>
+					</li>
+					<li>
+						<p>For some browsers, you may need to right-click or control-click the link
+							and choose "Save link as..." or a similar option to download the
+							file.</p>
+					</li>
+				</ul>
+				<h2><a name="tools" id="tools"></a>Bio-Formats tools downloads</h2>
+				<div class="alt-table">
+					<table width="800" border="0" cellpadding="5">
+						<tbody>
+							<tr>
+								<th width="269">Clients</th>
+								<th width="85">Size</th>
+								<th width="150">File Name</th>
+								<th width="125">Checksum</th>
+							</tr>
+							<tr>
+								<td><a href="@bioformats_package.jar@"><img
+											src="images/bf_package.png" alt="Bio-Formats Package"
+										 /></a></td>
+								<td align="center">@bioformats_package.jar_SIZE@</td>
+								<td>@bioformats_package.jar_BASE@</td>
+								<td align="center">@bioformats_package.jar_MD5@ (<a
+										href="@bioformats_package.jar@.md5">MD5</a>)</td>
+							</tr>
+							<tr>
+								<td><a href="@COMMAND_LINE_TOOLS@"><img src="images/bf_cm_tools.png"
+											alt="Command Line Tools" /></a></td>
+								<td align="center">@COMMAND_LINE_TOOLS_SIZE@</td>
+								<td>@COMMAND_LINE_TOOLS_BASE@</td>
+								<td align="center">@COMMAND_LINE_TOOLS_MD5@ (<a
+										href="@COMMAND_LINE_TOOLS@.md5">MD5</a>)</td>
+							</tr>
+							<tr>
+								<td><a href="@MATLAB_TOOLS@"><img src="images/bf_matlab_toolbox.png"
+											alt="MATLAB Toolbox" /></a></td>
+								<td align="center">@MATLAB_TOOLS_SIZE@</td>
+								<td>@MATLAB_TOOLS_BASE@</td>
+								<td align="center">@MATLAB_TOOLS_MD5@ (<a href="@MATLAB_TOOLS@.md5"
+										>MD5</a>)</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<ul>
+					<li>
+						<p>@bioformats_package.jar_BASE@ is the complete bundle (for end users)
+							containing everything needed to read images into ImageJ using
+							Bio-Formats. Instructions for installing Bio-Formats in ImageJ are
+							available in the <a href="@DOC_URL@/users/imagej/installing.html">user
+								guide</a>.</p>
+					</li>
+					<li>
+						<p>@COMMAND_LINE_TOOLS_BASE@ is a bundle of scripts for using Bio-Formats on
+							the command line <b>now with bioformats_package.jar included so you do
+								not have to install both separately</b>. See the <a
+								href="@DOC_URL@/users/comlinetools/index.html">command line tools
+								documentation</a> for further information.</p>
+					</li>
+					<li>
+						<p>@MATLAB_TOOLS_BASE@ is a bundle of functions for using Bio-Formats from
+							MATLAB <b>now with bioformats_package.jar included so you do not have to
+								install both separately</b>. See the <a
+								href="@DOC_URL@/users/matlab/index.html">MATLAB documentation</a>
+							for further information.</p>
+					</li>
+				</ul>
+				<h2><a name="api" id="api"></a>Bio-Formats API documentation</h2>
+				<div class="alt-table">
+					<table width="800" border="0" cellpadding="5">
+						<tbody>
+							<tr>
+								<th width="269">API Documentation</th>
+								<th width="85">Size</th>
+								<th width="150">File Name</th>
+								<th width="125">MD5 Checksum</th>
+							</tr>
+							<tr>
+								<td><a href="@JAVADOCS@"><img src="images/api_download.png"
+											alt="API Documentation Download" /></a></td>
+								<td align="center">@JAVADOCS_SIZE@</td>
+								<td>@JAVADOCS_BASE@</td>
+								<td align="center">@JAVADOCS_MD5@ (<a href="@DOCS@.md5"
+									>MD5</a>)</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<ul>
+					<li>
+						<p>The Bio-Formats API documentation is also available to read on the web <a
+								href="api">here</a></p>
+					</li>
+				</ul>
+				<h2><a name="components" id="components"></a>Bio-Formats components downloads</h2>
+				<div class="alt-table">
+					<table width="800" border="0" cellpadding="5">
+						<tbody>
+							<tr>
+								<th width="180">Project</th>
+								<th width="150">@VERSION@</th>
+								<th width="150">Latest build</th>
+								<th width="150">Daily build</th>
+							</tr>
+							<tr>
+								<th colspan="4">Packages</th>
+							</tr>
+							<tr>
+								<td>Bio-Formats package</td>
+								<td><a href="@bioformats_package.jar@"
+									>bioformats_package.jar</a></td>
+								<td><a href="@LATEST_bioformats_package.jar@"
+										>bioformats_package.jar</a></td>
+								<td><a href="@DAILY_bioformats_package.jar@"
+										>bioformats_package.jar</a></td>
+							</tr>
+							<tr>
+								<td>LOCI Tools</td>
+								<td><a href="@loci_tools.jar@">loci_tools.jar</a></td>
+								<td><a href="@LATEST_loci_tools.jar@">loci_tools.jar</a></td>
+								<td><a href="@DAILY_loci_tools.jar@">loci_tools.jar</a></td>
+							</tr>
+							<tr>
+								<th colspan="4">Core</th>
+							</tr>
+							<tr>
+								<td>Bio-Formats API library</td>
+								<td><a href="@formats-api.jar@">formats-api.jar</a></td>
+								<td><a href="@LATEST_formats-api.jar@">formats-api.jar</a></td>
+								<td><a href="@DAILY_formats-api.jar@">formats-api.jar</a></td>
+							</tr>
+							<tr>
+								<td>Bio-Formats BSD library</td>
+								<td><a href="@formats-bsd.jar@">formats-bsd.jar</a></td>
+								<td><a href="@LATEST_formats-bsd.jar@">formats-bsd.jar</a></td>
+								<td><a href="@DAILY_formats-bsd.jar@">formats-bsd.jar</a></td>
+							</tr>
+							<tr>
+								<td>Bio-Formats Common library</td>
+								<td><a href="@formats-common.jar@">formats-common.jar</a></td>
+								<td><a href="@LATEST_formats-common.jar@"
+									>formats-common.jar</a></td>
+								<td><a href="@DAILY_formats-common.jar@">formats-common.jar</a></td>
+							</tr>
+							<tr>
+								<td>Bio-Formats GPL library</td>
+								<td><a href="@formats-gpl.jar@">formats-gpl.jar</a></td>
+								<td><a href="@LATEST_formats-gpl.jar@">formats-gpl.jar</a></td>
+								<td><a href="@DAILY_formats-gpl.jar@">formats-gpl.jar</a></td>
+							</tr>
+							<tr>
+								<td>Bio-Formats BSD Test library</td>
+								<td><a href="@formats-bsd-test.jar@">formats-bsd-test.jar</a></td>
+								<td><a href="@LATEST_formats-bsd-test.jar@"
+									>formats-bsd-test.jar</a></td>
+								<td><a href="@DAILY_formats-bsd-test.jar@"
+									>formats-bsd-test.jar</a></td>
+							</tr>
+							<tr>
+								<td>OME-XML Java library</td>
+								<td><a href="@ome-xml.jar@">ome-xml.jar</a></td>
+								<td><a href="@LATEST_ome-xml.jar@">ome-xml.jar</a></td>
+								<td><a href="@DAILY_ome-xml.jar@">ome-xml.jar</a></td>
+							</tr>
+							<tr>
+								<td>OME Model Specification</td>
+								<td><a href="@specification.jar@">specification.jar</a></td>
+								<td><a href="@LATEST_specification.jar@">specification.jar</a></td>
+								<td><a href="@DAILY_specification.jar@">specification.jar</a></td>
+							</tr>
+							<tr>
+								<td>Bio-Formats Plugins for ImageJ</td>
+								<td><a href="@bio-formats_plugins.jar@"
+									>bio-formats_plugins.jar</a></td>
+								<td><a href="@LATEST_bio-formats_plugins.jar@"
+										>bio-formats_plugins.jar</a></td>
+								<td><a href="@DAILY_bio-formats_plugins.jar@"
+										>bio-formats_plugins.jar</a></td>
+							</tr>
+							<tr>
+								<td>Metakit</td>
+								<td><a href="@metakit.jar@">metakit.jar</a></td>
+								<td><a href="@LATEST_metakit.jar@">metakit.jar</a></td>
+								<td><a href="@DAILY_metakit.jar@">metakit.jar</a></td>
+							</tr>
+							<tr>
+								<td>Bio-Formats testing framework</td>
+								<td><a href="@bio-formats-testing-framework.jar@"
+										>bio-formats-testing-framework.jar</a></td>
+								<td><a href="@LATEST_bio-formats-testing-framework.jar@"
+										>bio-formats-testing-framework.jar</a></td>
+								<td><a href="@DAILY_bio-formats-testing-framework.jar@"
+										>bio-formats-testing-framework.jar</a></td>
+							</tr>
+							<tr>
+								<th align="center" colspan="4">Forks</th>
+							</tr>
+							<tr>
+								<td>JAI Image I/O Tools</td>
+								<td><a href="@jai_imageio.jar@">jai_imageio.jar</a></td>
+								<td><a href="@LATEST_jai_imageio.jar@">jai_imageio.jar</a></td>
+								<td><a href="@DAILY_jai_imageio.jar@">jai_imageio.jar</a></td>
+							</tr>
+							<tr>
+								<td>MDB Tools (Java port)</td>
+								<td><a href="@mdbtools-java.jar@">mdbtools-java.jar</a></td>
+								<td><a href="@LATEST_mdbtools-java.jar@">mdbtools-java.jar</a></td>
+								<td><a href="@DAILY_mdbtools-java.jar@">mdbtools-java.jar</a></td>
+							</tr>
+							<tr>
+								<td>Apache Jakarta POI</td>
+								<td><a href="@ome-poi.jar@">ome-poi.jar</a></td>
+								<td><a href="@LATEST_ome-poi.jar@">ome-poi.jar</a></td>
+								<td><a href="@DAILY_ome-poi.jar@">ome-poi.jar</a></td>
+							</tr>
+							<tr>
+								<td>TurboJPEG</td>
+								<td><a href="@turbojpeg.jar@">turbojpeg.jar</a></td>
+								<td><a href="@LATEST_turbojpeg.jar@">turbojpeg.jar</a></td>
+								<td><a href="@DAILY_turbojpeg.jar@">turbojpeg.jar</a></td>
+							</tr>
+							<tr>
+								<th align="center" colspan="4">Stubs</th>
+							</tr>
+							<tr>
+								<td>Luratech LuraWave stubs</td>
+								<td><a href="@lwf-stubs.jar@">lwf-stubs.jar</a></td>
+								<td><a href="@LATEST_lwf-stubs.jar@">lwf-stubs.jar</a></td>
+								<td><a href="@DAILY_lwf-stubs.jar@">lwf-stubs.jar</a></td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<h2><a name="code" id="code"></a>Source code</h2>
+				<div class="alt-table">
+					<table width="278" border="0" cellpadding="5">
+						<tbody>
+							<tr>
+								<th width="264">Source Code</th>
+							</tr>
+							<tr>
+								<td><a href="http://github.com/openmicroscopy/bioformats"
+										target="_blank"><img src="images/github_rep_link.png"
+											alt="GitHub Repository Link" /></a></td>
+							</tr>
+							<tr>
+								<td><a href="http://git.openmicroscopy.org/" target="_blank"><img
+											src="images/gitweb_int_link.png"
+											alt="Gitweb Interface Link" /></a></td>
+							</tr>
+							<tr>
+								<td><a href="@TAG_URL@" target="_blank"><img
+											src="images/git_tag.png" alt="GitHub Tag" /></a></td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<h2><a name="previous" id="previous"></a>Previous versions</h2>
+				<ul>
+					<li>
+						<p>Previous versions of Bio-Formats can be found on the <a
+								href="http://downloads.openmicroscopy.org/bio-formats/?C=M;O=D"
+								>Bio-Formats archive</a> page.</p>
+					</li>
+				</ul>
+			</div><!-- /.entry-content -->
+			<!-- </section> -->
+			<!-- <footer id="contentinfo" class="body">
+			</footer> --><!-- /#contentinfo -->
+			<!-- OME Footer - Start -->
+			<div class="visualClear" id="clear-space-before-footer"><!-- --></div>
+			<div id="portal-footer">
+				<p>
+					<acronym title="Copyright">&copy;</acronym> 2000-2014 University of Dundee &amp;
+					Open Microscopy Environment. <a
+						href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
+						>Creative Commons Attribution 3.0 Unported License</a>
+				</p>
+				<p> OME source code is available under the <a
+						href="http://www.openmicroscopy.org/site/about/licensing">GNU General public
+						license</a> or through commercial license from <a
+						href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software"
+						>Glencoe Software</a>
+				</p>
+			</div>
+			<div class="visualClear">
+				<!-- OME Footer - END -->
+			</div>
 		</div>
-		<div class="visualClear">
-		<!-- OME Footer - END -->
-
-</div></div></body></html>
+	</body>
+</html>

--- a/bf_downloads.html
+++ b/bf_downloads.html
@@ -86,7 +86,8 @@
                 <h2><a name="tools" id="tools"></a>Bio-Formats tools
                     downloads</h2>
                 <div class="alt-table">
-                    <table width="800" border="0" cellpadding="5">
+                    <table width="800" border="0" cellpadding="5" summary="Bio-Formats tools
+                    downloads">
                         <tbody>
                             <tr>
                                 <th width="269">Clients</th>
@@ -159,7 +160,8 @@
                 <h2><a name="api" id="api"></a>Bio-Formats API
                     documentation</h2>
                 <div class="alt-table">
-                    <table width="800" border="0" cellpadding="5">
+                    <table width="800" border="0" cellpadding="5" summary="Bio-Formats API
+                    documentation">
                         <tbody>
                             <tr>
                                 <th width="269">API Documentation</th>
@@ -189,7 +191,8 @@
                 <h2><a name="components" id="components"></a>Bio-Formats
                     components downloads</h2>
                 <div class="alt-table">
-                    <table width="800" border="0" cellpadding="5">
+                    <table width="800" border="0" cellpadding="5" summary="Bio-Formats
+                    components downloads">
                         <tbody>
                             <tr>
                                 <th width="180">Project</th>
@@ -367,7 +370,7 @@
                 </div>
                 <h2><a name="code" id="code"></a>Source code</h2>
                 <div class="alt-table">
-                    <table width="278" border="0" cellpadding="5">
+                    <table width="278" border="0" cellpadding="5" summary="Source code">
                         <tbody>
                             <tr>
                                 <th width="264">Source Code</th>

--- a/bf_downloads.html
+++ b/bf_downloads.html
@@ -51,9 +51,7 @@
         </div>
         <div class="visualClear" id="clear-space-before-wrapper-table">
             <!-- OME Banner - END -->
-            <!-- /#menu -->
-            <!-- <section id="content" class="body" style="margin-left:20px;"> -->
-            <div class="entry-content">
+            <div class="entry-content" style="margin-left:20px;">
                 <h2>Bio-Formats @VERSION@ Downloads</h2>
                 <p>
                     <strong><a href="#tools"
@@ -406,9 +404,7 @@
                     </li>
                 </ul>
             </div><!-- /.entry-content -->
-            <!-- </section> -->
-            <!-- <footer id="contentinfo" class="body">
-			</footer> --><!-- /#contentinfo -->
+
             <!-- OME Footer - Start -->
             <div class="visualClear" id="clear-space-before-footer"
                 ><!-- --></div>

--- a/bf_downloads.html
+++ b/bf_downloads.html
@@ -1,365 +1,432 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
-	<head>
-		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 
-		<link rel="stylesheet" href="images/plonematch.css" type="text/css" />
-		<style type="text/css">
-			[touch-action = "none"]{
-				-ms-touch-action:none;
-				touch-action:none;
-			}
-			[touch-action = "pan-x"]{
-				-ms-touch-action:pan-x;
-				touch-action:pan-x;
-			}
-			[touch-action = "pan-y"]{
-				-ms-touch-action:pan-y;
-				touch-action:pan-y;
-			}
-			[touch-action = "scroll"],
-			[touch-action = "pan-x pan-y"],
-			[touch-action = "pan-y pan-x"]{
-				-ms-touch-action:pan-x pan-y;
-				touch-action:pan-x pan-y;
-			}</style>
-		<title></title>
-	</head>
-	<body id="index" class="home">
-		<!-- OME Banner - START -->
-		<div id="portal-top">
-			<div id="portal-header">
-				<ul id="portal-siteactions">
-					<li>
-						<br />
-					</li>
-				</ul><a id="portal-logo" accesskey="1" href="http://downloads.openmicroscopy.org/"
-					name="portal-logo"><img src="images/logo.jpg" alt="" title="" height="73"
-						width="450" /></a>
-				<div id="portal-globalnav">
-					<br />
-				</div>
-			</div>
-			<div id="portal-personaltools-wrapper">
-				<ul id="portal-personaltools" class="visualInline">
-					<li>
-						<br />
-					</li>
-				</ul>
-			</div>
-		</div>
-		<div class="visualClear" id="clear-space-before-wrapper-table">
-			<!-- OME Banner - END -->
-			<!-- /#menu -->
-			<!-- <section id="content" class="body" style="margin-left:20px;"> -->
-			<div class="entry-content">
-				<h2>Bio-Formats @VERSION@ Downloads</h2>
-				<p>
-					<strong><a href="#tools">Tools</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#api"
-							>API</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#components"
-							>Components</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#code"
-							>Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#previous">Previous
-							versions</a>
-					</strong></p>
-				<ul>
-					<li>
-						<p>Full documentation is available as <a href="@DOC_URL@">web
-								documentation</a> or <a href="@DOC@">PDF documentation</a>.</p>
-					</li>
-					<li>
-						<p>Internet Explorer sometimes renames JAR files to ZIP (e.g.,
-							bioformats_package.jar becomes bioformats_package.zip); if this happens
-							to you, simply rename the file back to its original name after the
-							download is complete.</p>
-					</li>
-					<li>
-						<p>For some browsers, you may need to right-click or control-click the link
-							and choose "Save link as..." or a similar option to download the
-							file.</p>
-					</li>
-				</ul>
-				<h2><a name="tools" id="tools"></a>Bio-Formats tools downloads</h2>
-				<div class="alt-table">
-					<table width="800" border="0" cellpadding="5">
-						<tbody>
-							<tr>
-								<th width="269">Clients</th>
-								<th width="85">Size</th>
-								<th width="150">File Name</th>
-								<th width="125">Checksum</th>
-							</tr>
-							<tr>
-								<td><a href="@bioformats_package.jar@"><img
-											src="images/bf_package.png" alt="Bio-Formats Package"
-										 /></a></td>
-								<td align="center">@bioformats_package.jar_SIZE@</td>
-								<td>@bioformats_package.jar_BASE@</td>
-								<td align="center">@bioformats_package.jar_MD5@ (<a
-										href="@bioformats_package.jar@.md5">MD5</a>)</td>
-							</tr>
-							<tr>
-								<td><a href="@COMMAND_LINE_TOOLS@"><img src="images/bf_cm_tools.png"
-											alt="Command Line Tools" /></a></td>
-								<td align="center">@COMMAND_LINE_TOOLS_SIZE@</td>
-								<td>@COMMAND_LINE_TOOLS_BASE@</td>
-								<td align="center">@COMMAND_LINE_TOOLS_MD5@ (<a
-										href="@COMMAND_LINE_TOOLS@.md5">MD5</a>)</td>
-							</tr>
-							<tr>
-								<td><a href="@MATLAB_TOOLS@"><img src="images/bf_matlab_toolbox.png"
-											alt="MATLAB Toolbox" /></a></td>
-								<td align="center">@MATLAB_TOOLS_SIZE@</td>
-								<td>@MATLAB_TOOLS_BASE@</td>
-								<td align="center">@MATLAB_TOOLS_MD5@ (<a href="@MATLAB_TOOLS@.md5"
-										>MD5</a>)</td>
-							</tr>
-						</tbody>
-					</table>
-				</div>
-				<ul>
-					<li>
-						<p>@bioformats_package.jar_BASE@ is the complete bundle (for end users)
-							containing everything needed to read images into ImageJ using
-							Bio-Formats. Instructions for installing Bio-Formats in ImageJ are
-							available in the <a href="@DOC_URL@/users/imagej/installing.html">user
-								guide</a>.</p>
-					</li>
-					<li>
-						<p>@COMMAND_LINE_TOOLS_BASE@ is a bundle of scripts for using Bio-Formats on
-							the command line <b>now with bioformats_package.jar included so you do
-								not have to install both separately</b>. See the <a
-								href="@DOC_URL@/users/comlinetools/index.html">command line tools
-								documentation</a> for further information.</p>
-					</li>
-					<li>
-						<p>@MATLAB_TOOLS_BASE@ is a bundle of functions for using Bio-Formats from
-							MATLAB <b>now with bioformats_package.jar included so you do not have to
-								install both separately</b>. See the <a
-								href="@DOC_URL@/users/matlab/index.html">MATLAB documentation</a>
-							for further information.</p>
-					</li>
-				</ul>
-				<h2><a name="api" id="api"></a>Bio-Formats API documentation</h2>
-				<div class="alt-table">
-					<table width="800" border="0" cellpadding="5">
-						<tbody>
-							<tr>
-								<th width="269">API Documentation</th>
-								<th width="85">Size</th>
-								<th width="150">File Name</th>
-								<th width="125">MD5 Checksum</th>
-							</tr>
-							<tr>
-								<td><a href="@JAVADOCS@"><img src="images/api_download.png"
-											alt="API Documentation Download" /></a></td>
-								<td align="center">@JAVADOCS_SIZE@</td>
-								<td>@JAVADOCS_BASE@</td>
-								<td align="center">@JAVADOCS_MD5@ (<a href="@DOCS@.md5"
-									>MD5</a>)</td>
-							</tr>
-						</tbody>
-					</table>
-				</div>
-				<ul>
-					<li>
-						<p>The Bio-Formats API documentation is also available to read on the web <a
-								href="api">here</a></p>
-					</li>
-				</ul>
-				<h2><a name="components" id="components"></a>Bio-Formats components downloads</h2>
-				<div class="alt-table">
-					<table width="800" border="0" cellpadding="5">
-						<tbody>
-							<tr>
-								<th width="180">Project</th>
-								<th width="150">@VERSION@</th>
-								<th width="150">Latest build</th>
-								<th width="150">Daily build</th>
-							</tr>
-							<tr>
-								<th colspan="4">Packages</th>
-							</tr>
-							<tr>
-								<td>Bio-Formats package</td>
-								<td><a href="@bioformats_package.jar@"
-									>bioformats_package.jar</a></td>
-								<td><a href="@LATEST_bioformats_package.jar@"
-										>bioformats_package.jar</a></td>
-								<td><a href="@DAILY_bioformats_package.jar@"
-										>bioformats_package.jar</a></td>
-							</tr>
-							<tr>
-								<td>LOCI Tools</td>
-								<td><a href="@loci_tools.jar@">loci_tools.jar</a></td>
-								<td><a href="@LATEST_loci_tools.jar@">loci_tools.jar</a></td>
-								<td><a href="@DAILY_loci_tools.jar@">loci_tools.jar</a></td>
-							</tr>
-							<tr>
-								<th colspan="4">Core</th>
-							</tr>
-							<tr>
-								<td>Bio-Formats API library</td>
-								<td><a href="@formats-api.jar@">formats-api.jar</a></td>
-								<td><a href="@LATEST_formats-api.jar@">formats-api.jar</a></td>
-								<td><a href="@DAILY_formats-api.jar@">formats-api.jar</a></td>
-							</tr>
-							<tr>
-								<td>Bio-Formats BSD library</td>
-								<td><a href="@formats-bsd.jar@">formats-bsd.jar</a></td>
-								<td><a href="@LATEST_formats-bsd.jar@">formats-bsd.jar</a></td>
-								<td><a href="@DAILY_formats-bsd.jar@">formats-bsd.jar</a></td>
-							</tr>
-							<tr>
-								<td>Bio-Formats Common library</td>
-								<td><a href="@formats-common.jar@">formats-common.jar</a></td>
-								<td><a href="@LATEST_formats-common.jar@"
-									>formats-common.jar</a></td>
-								<td><a href="@DAILY_formats-common.jar@">formats-common.jar</a></td>
-							</tr>
-							<tr>
-								<td>Bio-Formats GPL library</td>
-								<td><a href="@formats-gpl.jar@">formats-gpl.jar</a></td>
-								<td><a href="@LATEST_formats-gpl.jar@">formats-gpl.jar</a></td>
-								<td><a href="@DAILY_formats-gpl.jar@">formats-gpl.jar</a></td>
-							</tr>
-							<tr>
-								<td>Bio-Formats BSD Test library</td>
-								<td><a href="@formats-bsd-test.jar@">formats-bsd-test.jar</a></td>
-								<td><a href="@LATEST_formats-bsd-test.jar@"
-									>formats-bsd-test.jar</a></td>
-								<td><a href="@DAILY_formats-bsd-test.jar@"
-									>formats-bsd-test.jar</a></td>
-							</tr>
-							<tr>
-								<td>OME-XML Java library</td>
-								<td><a href="@ome-xml.jar@">ome-xml.jar</a></td>
-								<td><a href="@LATEST_ome-xml.jar@">ome-xml.jar</a></td>
-								<td><a href="@DAILY_ome-xml.jar@">ome-xml.jar</a></td>
-							</tr>
-							<tr>
-								<td>OME Model Specification</td>
-								<td><a href="@specification.jar@">specification.jar</a></td>
-								<td><a href="@LATEST_specification.jar@">specification.jar</a></td>
-								<td><a href="@DAILY_specification.jar@">specification.jar</a></td>
-							</tr>
-							<tr>
-								<td>Bio-Formats Plugins for ImageJ</td>
-								<td><a href="@bio-formats_plugins.jar@"
-									>bio-formats_plugins.jar</a></td>
-								<td><a href="@LATEST_bio-formats_plugins.jar@"
-										>bio-formats_plugins.jar</a></td>
-								<td><a href="@DAILY_bio-formats_plugins.jar@"
-										>bio-formats_plugins.jar</a></td>
-							</tr>
-							<tr>
-								<td>Metakit</td>
-								<td><a href="@metakit.jar@">metakit.jar</a></td>
-								<td><a href="@LATEST_metakit.jar@">metakit.jar</a></td>
-								<td><a href="@DAILY_metakit.jar@">metakit.jar</a></td>
-							</tr>
-							<tr>
-								<td>Bio-Formats testing framework</td>
-								<td><a href="@bio-formats-testing-framework.jar@"
-										>bio-formats-testing-framework.jar</a></td>
-								<td><a href="@LATEST_bio-formats-testing-framework.jar@"
-										>bio-formats-testing-framework.jar</a></td>
-								<td><a href="@DAILY_bio-formats-testing-framework.jar@"
-										>bio-formats-testing-framework.jar</a></td>
-							</tr>
-							<tr>
-								<th align="center" colspan="4">Forks</th>
-							</tr>
-							<tr>
-								<td>JAI Image I/O Tools</td>
-								<td><a href="@jai_imageio.jar@">jai_imageio.jar</a></td>
-								<td><a href="@LATEST_jai_imageio.jar@">jai_imageio.jar</a></td>
-								<td><a href="@DAILY_jai_imageio.jar@">jai_imageio.jar</a></td>
-							</tr>
-							<tr>
-								<td>MDB Tools (Java port)</td>
-								<td><a href="@mdbtools-java.jar@">mdbtools-java.jar</a></td>
-								<td><a href="@LATEST_mdbtools-java.jar@">mdbtools-java.jar</a></td>
-								<td><a href="@DAILY_mdbtools-java.jar@">mdbtools-java.jar</a></td>
-							</tr>
-							<tr>
-								<td>Apache Jakarta POI</td>
-								<td><a href="@ome-poi.jar@">ome-poi.jar</a></td>
-								<td><a href="@LATEST_ome-poi.jar@">ome-poi.jar</a></td>
-								<td><a href="@DAILY_ome-poi.jar@">ome-poi.jar</a></td>
-							</tr>
-							<tr>
-								<td>TurboJPEG</td>
-								<td><a href="@turbojpeg.jar@">turbojpeg.jar</a></td>
-								<td><a href="@LATEST_turbojpeg.jar@">turbojpeg.jar</a></td>
-								<td><a href="@DAILY_turbojpeg.jar@">turbojpeg.jar</a></td>
-							</tr>
-							<tr>
-								<th align="center" colspan="4">Stubs</th>
-							</tr>
-							<tr>
-								<td>Luratech LuraWave stubs</td>
-								<td><a href="@lwf-stubs.jar@">lwf-stubs.jar</a></td>
-								<td><a href="@LATEST_lwf-stubs.jar@">lwf-stubs.jar</a></td>
-								<td><a href="@DAILY_lwf-stubs.jar@">lwf-stubs.jar</a></td>
-							</tr>
-						</tbody>
-					</table>
-				</div>
-				<h2><a name="code" id="code"></a>Source code</h2>
-				<div class="alt-table">
-					<table width="278" border="0" cellpadding="5">
-						<tbody>
-							<tr>
-								<th width="264">Source Code</th>
-							</tr>
-							<tr>
-								<td><a href="http://github.com/openmicroscopy/bioformats"
-										target="_blank"><img src="images/github_rep_link.png"
-											alt="GitHub Repository Link" /></a></td>
-							</tr>
-							<tr>
-								<td><a href="http://git.openmicroscopy.org/" target="_blank"><img
-											src="images/gitweb_int_link.png"
-											alt="Gitweb Interface Link" /></a></td>
-							</tr>
-							<tr>
-								<td><a href="@TAG_URL@" target="_blank"><img
-											src="images/git_tag.png" alt="GitHub Tag" /></a></td>
-							</tr>
-						</tbody>
-					</table>
-				</div>
-				<h2><a name="previous" id="previous"></a>Previous versions</h2>
-				<ul>
-					<li>
-						<p>Previous versions of Bio-Formats can be found on the <a
-								href="http://downloads.openmicroscopy.org/bio-formats/?C=M;O=D"
-								>Bio-Formats archive</a> page.</p>
-					</li>
-				</ul>
-			</div><!-- /.entry-content -->
-			<!-- </section> -->
-			<!-- <footer id="contentinfo" class="body">
+        <link rel="stylesheet" href="images/plonematch.css" type="text/css" />
+        <style type="text/css">
+            [touch-action = "none"]{
+                -ms-touch-action:none;
+                touch-action:none;
+            }
+            [touch-action = "pan-x"]{
+                -ms-touch-action:pan-x;
+                touch-action:pan-x;
+            }
+            [touch-action = "pan-y"]{
+                -ms-touch-action:pan-y;
+                touch-action:pan-y;
+            }
+            [touch-action = "scroll"],
+            [touch-action = "pan-x pan-y"],
+            [touch-action = "pan-y pan-x"]{
+                -ms-touch-action:pan-x pan-y;
+                touch-action:pan-x pan-y;
+            }</style>
+        <title></title>
+    </head>
+    <body id="index" class="home">
+        <!-- OME Banner - START -->
+        <div id="portal-top">
+            <div id="portal-header">
+                <ul id="portal-siteactions">
+                    <li>
+                        <br />
+                    </li>
+                </ul><a id="portal-logo" accesskey="1"
+                    href="http://downloads.openmicroscopy.org/"
+                    name="portal-logo"><img src="images/logo.jpg" alt=""
+                        title="" height="73" width="450" /></a>
+                <div id="portal-globalnav">
+                    <br />
+                </div>
+            </div>
+            <div id="portal-personaltools-wrapper">
+                <ul id="portal-personaltools" class="visualInline">
+                    <li>
+                        <br />
+                    </li>
+                </ul>
+            </div>
+        </div>
+        <div class="visualClear" id="clear-space-before-wrapper-table">
+            <!-- OME Banner - END -->
+            <!-- /#menu -->
+            <!-- <section id="content" class="body" style="margin-left:20px;"> -->
+            <div class="entry-content">
+                <h2>Bio-Formats @VERSION@ Downloads</h2>
+                <p>
+                    <strong><a href="#tools"
+                            >Tools</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#api"
+                            >API</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
+                            href="#components"
+                            >Components</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
+                            href="#code">Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
+                            href="#previous">Previous versions</a>
+                    </strong></p>
+                <ul>
+                    <li>
+                        <p>Full documentation is available as <a
+                                href="@DOC_URL@">web documentation</a> or <a
+                                href="@DOC@">PDF documentation</a>.</p>
+                    </li>
+                    <li>
+                        <p>Internet Explorer sometimes renames JAR files to ZIP
+                            (e.g., bioformats_package.jar becomes
+                            bioformats_package.zip); if this happens to you,
+                            simply rename the file back to its original name
+                            after the download is complete.</p>
+                    </li>
+                    <li>
+                        <p>For some browsers, you may need to right-click or
+                            control-click the link and choose "Save link as..."
+                            or a similar option to download the file.</p>
+                    </li>
+                </ul>
+                <h2><a name="tools" id="tools"></a>Bio-Formats tools
+                    downloads</h2>
+                <div class="alt-table">
+                    <table width="800" border="0" cellpadding="5">
+                        <tbody>
+                            <tr>
+                                <th width="269">Clients</th>
+                                <th width="85">Size</th>
+                                <th width="150">File Name</th>
+                                <th width="125">Checksum</th>
+                            </tr>
+                            <tr>
+                                <td><a href="@bioformats_package.jar@"><img
+                                        src="images/bf_package.png"
+                                        alt="Bio-Formats Package" /></a></td>
+                                <td align="center"
+                                    >@bioformats_package.jar_SIZE@</td>
+                                <td>@bioformats_package.jar_BASE@</td>
+                                <td align="center">@bioformats_package.jar_MD5@
+                                        (<a href="@bioformats_package.jar@.md5"
+                                        >MD5</a>)</td>
+                            </tr>
+                            <tr>
+                                <td><a href="@COMMAND_LINE_TOOLS@"><img
+                                        src="images/bf_cm_tools.png"
+                                        alt="Command Line Tools" /></a></td>
+                                <td align="center"
+                                    >@COMMAND_LINE_TOOLS_SIZE@</td>
+                                <td>@COMMAND_LINE_TOOLS_BASE@</td>
+                                <td align="center">@COMMAND_LINE_TOOLS_MD5@ (<a
+                                        href="@COMMAND_LINE_TOOLS@.md5"
+                                    >MD5</a>)</td>
+                            </tr>
+                            <tr>
+                                <td><a href="@MATLAB_TOOLS@"><img
+                                        src="images/bf_matlab_toolbox.png"
+                                        alt="MATLAB Toolbox" /></a></td>
+                                <td align="center">@MATLAB_TOOLS_SIZE@</td>
+                                <td>@MATLAB_TOOLS_BASE@</td>
+                                <td align="center">@MATLAB_TOOLS_MD5@ (<a
+                                        href="@MATLAB_TOOLS@.md5">MD5</a>)</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <ul>
+                    <li>
+                        <p>@bioformats_package.jar_BASE@ is the complete bundle
+                            (for end users) containing everything needed to read
+                            images into ImageJ using Bio-Formats. Instructions
+                            for installing Bio-Formats in ImageJ are available
+                            in the <a
+                                href="@DOC_URL@/users/imagej/installing.html"
+                                >user guide</a>.</p>
+                    </li>
+                    <li>
+                        <p>@COMMAND_LINE_TOOLS_BASE@ is a bundle of scripts for
+                            using Bio-Formats on the command line <b>now with
+                                bioformats_package.jar included so you do not
+                                have to install both separately</b>. See the <a
+                                href="@DOC_URL@/users/comlinetools/index.html"
+                                >command line tools documentation</a> for
+                            further information.</p>
+                    </li>
+                    <li>
+                        <p>@MATLAB_TOOLS_BASE@ is a bundle of functions for
+                            using Bio-Formats from MATLAB <b>now with
+                                bioformats_package.jar included so you do not
+                                have to install both separately</b>. See the <a
+                                href="@DOC_URL@/users/matlab/index.html">MATLAB
+                                documentation</a> for further information.</p>
+                    </li>
+                </ul>
+                <h2><a name="api" id="api"></a>Bio-Formats API
+                    documentation</h2>
+                <div class="alt-table">
+                    <table width="800" border="0" cellpadding="5">
+                        <tbody>
+                            <tr>
+                                <th width="269">API Documentation</th>
+                                <th width="85">Size</th>
+                                <th width="150">File Name</th>
+                                <th width="125">MD5 Checksum</th>
+                            </tr>
+                            <tr>
+                                <td><a href="@JAVADOCS@"><img
+                                        src="images/api_download.png"
+                                        alt="API Documentation Download"
+                                     /></a></td>
+                                <td align="center">@JAVADOCS_SIZE@</td>
+                                <td>@JAVADOCS_BASE@</td>
+                                <td align="center">@JAVADOCS_MD5@ (<a
+                                        href="@DOCS@.md5">MD5</a>)</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <ul>
+                    <li>
+                        <p>The Bio-Formats API documentation is also available
+                            to read on the web <a href="api">here</a></p>
+                    </li>
+                </ul>
+                <h2><a name="components" id="components"></a>Bio-Formats
+                    components downloads</h2>
+                <div class="alt-table">
+                    <table width="800" border="0" cellpadding="5">
+                        <tbody>
+                            <tr>
+                                <th width="180">Project</th>
+                                <th width="150">@VERSION@</th>
+                                <th width="150">Latest build</th>
+                                <th width="150">Daily build</th>
+                            </tr>
+                            <tr>
+                                <th colspan="4">Packages</th>
+                            </tr>
+                            <tr>
+                                <td>Bio-Formats package</td>
+                                <td><a href="@bioformats_package.jar@"
+                                        >bioformats_package.jar</a></td>
+                                <td><a href="@LATEST_bioformats_package.jar@"
+                                        >bioformats_package.jar</a></td>
+                                <td><a href="@DAILY_bioformats_package.jar@"
+                                        >bioformats_package.jar</a></td>
+                            </tr>
+                            <tr>
+                                <td>LOCI Tools</td>
+                                <td><a href="@loci_tools.jar@"
+                                        >loci_tools.jar</a></td>
+                                <td><a href="@LATEST_loci_tools.jar@"
+                                        >loci_tools.jar</a></td>
+                                <td><a href="@DAILY_loci_tools.jar@"
+                                        >loci_tools.jar</a></td>
+                            </tr>
+                            <tr>
+                                <th colspan="4">Core</th>
+                            </tr>
+                            <tr>
+                                <td>Bio-Formats API library</td>
+                                <td><a href="@formats-api.jar@"
+                                        >formats-api.jar</a></td>
+                                <td><a href="@LATEST_formats-api.jar@"
+                                        >formats-api.jar</a></td>
+                                <td><a href="@DAILY_formats-api.jar@"
+                                        >formats-api.jar</a></td>
+                            </tr>
+                            <tr>
+                                <td>Bio-Formats BSD library</td>
+                                <td><a href="@formats-bsd.jar@"
+                                        >formats-bsd.jar</a></td>
+                                <td><a href="@LATEST_formats-bsd.jar@"
+                                        >formats-bsd.jar</a></td>
+                                <td><a href="@DAILY_formats-bsd.jar@"
+                                        >formats-bsd.jar</a></td>
+                            </tr>
+                            <tr>
+                                <td>Bio-Formats Common library</td>
+                                <td><a href="@formats-common.jar@"
+                                        >formats-common.jar</a></td>
+                                <td><a href="@LATEST_formats-common.jar@"
+                                        >formats-common.jar</a></td>
+                                <td><a href="@DAILY_formats-common.jar@"
+                                        >formats-common.jar</a></td>
+                            </tr>
+                            <tr>
+                                <td>Bio-Formats GPL library</td>
+                                <td><a href="@formats-gpl.jar@"
+                                        >formats-gpl.jar</a></td>
+                                <td><a href="@LATEST_formats-gpl.jar@"
+                                        >formats-gpl.jar</a></td>
+                                <td><a href="@DAILY_formats-gpl.jar@"
+                                        >formats-gpl.jar</a></td>
+                            </tr>
+                            <tr>
+                                <td>Bio-Formats BSD Test library</td>
+                                <td><a href="@formats-bsd-test.jar@"
+                                        >formats-bsd-test.jar</a></td>
+                                <td><a href="@LATEST_formats-bsd-test.jar@"
+                                        >formats-bsd-test.jar</a></td>
+                                <td><a href="@DAILY_formats-bsd-test.jar@"
+                                        >formats-bsd-test.jar</a></td>
+                            </tr>
+                            <tr>
+                                <td>OME-XML Java library</td>
+                                <td><a href="@ome-xml.jar@">ome-xml.jar</a></td>
+                                <td><a href="@LATEST_ome-xml.jar@"
+                                        >ome-xml.jar</a></td>
+                                <td><a href="@DAILY_ome-xml.jar@"
+                                        >ome-xml.jar</a></td>
+                            </tr>
+                            <tr>
+                                <td>OME Model Specification</td>
+                                <td><a href="@specification.jar@"
+                                        >specification.jar</a></td>
+                                <td><a href="@LATEST_specification.jar@"
+                                        >specification.jar</a></td>
+                                <td><a href="@DAILY_specification.jar@"
+                                        >specification.jar</a></td>
+                            </tr>
+                            <tr>
+                                <td>Bio-Formats Plugins for ImageJ</td>
+                                <td><a href="@bio-formats_plugins.jar@"
+                                        >bio-formats_plugins.jar</a></td>
+                                <td><a href="@LATEST_bio-formats_plugins.jar@"
+                                        >bio-formats_plugins.jar</a></td>
+                                <td><a href="@DAILY_bio-formats_plugins.jar@"
+                                        >bio-formats_plugins.jar</a></td>
+                            </tr>
+                            <tr>
+                                <td>Metakit</td>
+                                <td><a href="@metakit.jar@">metakit.jar</a></td>
+                                <td><a href="@LATEST_metakit.jar@"
+                                        >metakit.jar</a></td>
+                                <td><a href="@DAILY_metakit.jar@"
+                                        >metakit.jar</a></td>
+                            </tr>
+                            <tr>
+                                <td>Bio-Formats testing framework</td>
+                                <td><a
+                                        href="@bio-formats-testing-framework.jar@"
+                                        >bio-formats-testing-framework.jar</a></td>
+                                <td><a
+                                        href="@LATEST_bio-formats-testing-framework.jar@"
+                                        >bio-formats-testing-framework.jar</a></td>
+                                <td><a
+                                        href="@DAILY_bio-formats-testing-framework.jar@"
+                                        >bio-formats-testing-framework.jar</a></td>
+                            </tr>
+                            <tr>
+                                <th align="center" colspan="4">Forks</th>
+                            </tr>
+                            <tr>
+                                <td>JAI Image I/O Tools</td>
+                                <td><a href="@jai_imageio.jar@"
+                                        >jai_imageio.jar</a></td>
+                                <td><a href="@LATEST_jai_imageio.jar@"
+                                        >jai_imageio.jar</a></td>
+                                <td><a href="@DAILY_jai_imageio.jar@"
+                                        >jai_imageio.jar</a></td>
+                            </tr>
+                            <tr>
+                                <td>MDB Tools (Java port)</td>
+                                <td><a href="@mdbtools-java.jar@"
+                                        >mdbtools-java.jar</a></td>
+                                <td><a href="@LATEST_mdbtools-java.jar@"
+                                        >mdbtools-java.jar</a></td>
+                                <td><a href="@DAILY_mdbtools-java.jar@"
+                                        >mdbtools-java.jar</a></td>
+                            </tr>
+                            <tr>
+                                <td>Apache Jakarta POI</td>
+                                <td><a href="@ome-poi.jar@">ome-poi.jar</a></td>
+                                <td><a href="@LATEST_ome-poi.jar@"
+                                        >ome-poi.jar</a></td>
+                                <td><a href="@DAILY_ome-poi.jar@"
+                                        >ome-poi.jar</a></td>
+                            </tr>
+                            <tr>
+                                <td>TurboJPEG</td>
+                                <td><a href="@turbojpeg.jar@"
+                                    >turbojpeg.jar</a></td>
+                                <td><a href="@LATEST_turbojpeg.jar@"
+                                        >turbojpeg.jar</a></td>
+                                <td><a href="@DAILY_turbojpeg.jar@"
+                                        >turbojpeg.jar</a></td>
+                            </tr>
+                            <tr>
+                                <th align="center" colspan="4">Stubs</th>
+                            </tr>
+                            <tr>
+                                <td>Luratech LuraWave stubs</td>
+                                <td><a href="@lwf-stubs.jar@"
+                                    >lwf-stubs.jar</a></td>
+                                <td><a href="@LATEST_lwf-stubs.jar@"
+                                        >lwf-stubs.jar</a></td>
+                                <td><a href="@DAILY_lwf-stubs.jar@"
+                                        >lwf-stubs.jar</a></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <h2><a name="code" id="code"></a>Source code</h2>
+                <div class="alt-table">
+                    <table width="278" border="0" cellpadding="5">
+                        <tbody>
+                            <tr>
+                                <th width="264">Source Code</th>
+                            </tr>
+                            <tr>
+                                <td><a
+                                        href="http://github.com/openmicroscopy/bioformats"
+                                        target="_blank"><img
+                                        src="images/github_rep_link.png"
+                                        alt="GitHub Repository Link" /></a></td>
+                            </tr>
+                            <tr>
+                                <td><a href="http://git.openmicroscopy.org/"
+                                        target="_blank"><img
+                                        src="images/gitweb_int_link.png"
+                                        alt="Gitweb Interface Link" /></a></td>
+                            </tr>
+                            <tr>
+                                <td><a href="@TAG_URL@" target="_blank"><img
+                                        src="images/git_tag.png"
+                                        alt="GitHub Tag" /></a></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <h2><a name="previous" id="previous"></a>Previous versions</h2>
+                <ul>
+                    <li>
+                        <p>Previous versions of Bio-Formats can be found on the
+                                <a
+                                href="http://downloads.openmicroscopy.org/bio-formats/?C=M;O=D"
+                                >Bio-Formats archive</a> page.</p>
+                    </li>
+                </ul>
+            </div><!-- /.entry-content -->
+            <!-- </section> -->
+            <!-- <footer id="contentinfo" class="body">
 			</footer> --><!-- /#contentinfo -->
-			<!-- OME Footer - Start -->
-			<div class="visualClear" id="clear-space-before-footer"><!-- --></div>
-			<div id="portal-footer">
-				<p>
-					<acronym title="Copyright">&copy;</acronym> 2000-2014 University of Dundee &amp;
-					Open Microscopy Environment. <a
-						href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
-						>Creative Commons Attribution 3.0 Unported License</a>
-				</p>
-				<p> OME source code is available under the <a
-						href="http://www.openmicroscopy.org/site/about/licensing">GNU General public
-						license</a> or through commercial license from <a
-						href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software"
-						>Glencoe Software</a>
-				</p>
-			</div>
-			<div class="visualClear">
-				<!-- OME Footer - END -->
-			</div>
-		</div>
-	</body>
+            <!-- OME Footer - Start -->
+            <div class="visualClear" id="clear-space-before-footer"
+                ><!-- --></div>
+            <div id="portal-footer">
+                <p>
+                    <acronym title="Copyright">&copy;</acronym> 2000-2014
+                    University of Dundee &amp; Open Microscopy Environment. <a
+                        href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
+                        >Creative Commons Attribution 3.0 Unported License</a>
+                </p>
+                <p> OME source code is available under the <a
+                        href="http://www.openmicroscopy.org/site/about/licensing"
+                        >GNU General public license</a> or through commercial
+                    license from <a
+                        href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software"
+                        >Glencoe Software</a>
+                </p>
+            </div>
+            <div class="visualClear">
+                <!-- OME Footer - END -->
+            </div>
+        </div>
+    </body>
 </html>

--- a/figure_downloads.html
+++ b/figure_downloads.html
@@ -52,53 +52,54 @@
         </div>
         <div class="visualClear" id="clear-space-before-wrapper-table">
             <!-- OME Banner - END -->
-            <!-- /#menu -->
-            <!-- <section id="content" class="body" style="margin-left:20px;"> <div class="entry-content"> -->
-            <h2>OMERO.figure @VERSION@</h2>
-            <ul>
-                <li>
-                    <p>Information on this release of OMERO.figure is in the <a
-                            href="@ANNOUCEMENT_URL@">release announcement</a>.
-                    </p>
-                </li>
+            <div class="entry-content" style="margin-left:20px;">
+                <h2>OMERO.figure @VERSION@</h2>
+                <ul>
+                    <li>
+                        <p>Information on this release of OMERO.figure is in the
+                                <a href="@ANNOUCEMENT_URL@">release
+                                announcement</a>. </p>
+                    </li>
 
-                <li>
-                    <p>Full documentation is available as <a
-                            href="http://will-moore.github.io/figure/">web
-                            documentation</a>.</p>
-                </li>
+                    <li>
+                        <p>Full documentation is available as <a
+                                href="http://will-moore.github.io/figure/">web
+                                documentation</a>.</p>
+                    </li>
 
-                <li>
-                    <p>Source code and the latest development version can be
-                        found on <a href="https://github.com/will-moore/figure"
-                            >GitHub</a>.</p>
-                </li>
-            </ul>
-            <h2>Downloads</h2>
-            <div class="alt-table">
-                <table width="800" border="0" cellpadding="5" summary="Downloads">
-                    <tbody>
-                        <tr>
-                            <th width="269">File</th>
-                            <th width="85">Size</th>
-                            <th width="271">File Name</th>
-                            <th width="125">Checksum</th>
-                        </tr>
-                        <tr>
-                            <td><a href="@FIGURE@"><img
+                    <li>
+                        <p>Source code and the latest development version can be
+                            found on <a
+                                href="https://github.com/will-moore/figure"
+                                >GitHub</a>.</p>
+                    </li>
+                </ul>
+                <h2>Downloads</h2>
+                <div class="alt-table">
+                    <table width="800" border="0" cellpadding="5"
+                        summary="Downloads">
+                        <tbody>
+                            <tr>
+                                <th width="269">File</th>
+                                <th width="85">Size</th>
+                                <th width="271">File Name</th>
+                                <th width="125">Checksum</th>
+                            </tr>
+                            <tr>
+                                <td><a href="@FIGURE@"><img
                                         src="images/omero_figure.png"
                                         alt="OMERO.figure Download" /></a></td>
-                            <td align="center">@FIGURE_SIZE@</td>
-                            <td>@FIGURE_BASE@</td>
-                            <td align="center">@FIGURE_MD5@ (<a
-                                    href="@FIGURE@.md5">MD5</a>)</td>
-                        </tr>
-                    </tbody>
-                </table>
+                                <td align="center">@FIGURE_SIZE@</td>
+                                <td>@FIGURE_BASE@</td>
+                                <td align="center">@FIGURE_MD5@ (<a
+                                        href="@FIGURE@.md5">MD5</a>)</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
             </div>
         </div><!-- /.entry-content -->
-        <!-- </section> -->
-        <!-- <footer id="contentinfo" class="body"> </footer> --><!-- /#contentinfo -->
+
         <!-- OME Footer - Start -->
         <div class="visualClear" id="clear-space-before-footer"><!-- --></div>
         <div id="portal-footer">

--- a/figure_downloads.html
+++ b/figure_downloads.html
@@ -1,116 +1,123 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
-	<head>
-		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 
-		<link rel="stylesheet" href="images/plonematch.css" type="text/css" />
+        <link rel="stylesheet" href="images/plonematch.css" type="text/css" />
 
-		<style type="text/css">
-			[touch-action = "none"]{
-				-ms-touch-action:none;
-				touch-action:none;
-			}
-			[touch-action = "pan-x"]{
-				-ms-touch-action:pan-x;
-				touch-action:pan-x;
-			}
-			[touch-action = "pan-y"]{
-				-ms-touch-action:pan-y;
-				touch-action:pan-y;
-			}
-			[touch-action = "scroll"],
-			[touch-action = "pan-x pan-y"],
-			[touch-action = "pan-y pan-x"]{
-				-ms-touch-action:pan-x pan-y;
-				touch-action:pan-x pan-y;
-			}</style>
-		<title></title>
-	</head>
-	<body id="index" class="home">
-		<!-- OME Banner - START -->
-		<div id="portal-top">
-			<div id="portal-header">
-				<ul id="portal-siteactions">
-					<li>
-						<br />
-					</li>
-				</ul><a id="portal-logo" accesskey="1" href="http://downloads.openmicroscopy.org/"
-					name="portal-logo"><img src="images/logo.jpg" alt="" title="" height="73"
-						width="450" /></a>
-				<div id="portal-globalnav">
-					<br />
-				</div>
-			</div>
-			<div id="portal-personaltools-wrapper">
-				<ul id="portal-personaltools" class="visualInline">
-					<li>
-						<br />
-					</li>
-				</ul>
-			</div>
-		</div>
-		<div class="visualClear" id="clear-space-before-wrapper-table">
-			<!-- OME Banner - END -->
-			<!-- /#menu -->
-			<!-- <section id="content" class="body" style="margin-left:20px;"> <div class="entry-content"> -->
-			<h2>OMERO.figure @VERSION@</h2>
-			<ul>
-				<li>
-					<p>Information on this release of OMERO.figure is in the <a
-							href="@ANNOUCEMENT_URL@">release announcement</a>. </p>
-				</li>
+        <style type="text/css">
+            [touch-action = "none"]{
+                -ms-touch-action:none;
+                touch-action:none;
+            }
+            [touch-action = "pan-x"]{
+                -ms-touch-action:pan-x;
+                touch-action:pan-x;
+            }
+            [touch-action = "pan-y"]{
+                -ms-touch-action:pan-y;
+                touch-action:pan-y;
+            }
+            [touch-action = "scroll"],
+            [touch-action = "pan-x pan-y"],
+            [touch-action = "pan-y pan-x"]{
+                -ms-touch-action:pan-x pan-y;
+                touch-action:pan-x pan-y;
+            }</style>
+        <title></title>
+    </head>
+    <body id="index" class="home">
+        <!-- OME Banner - START -->
+        <div id="portal-top">
+            <div id="portal-header">
+                <ul id="portal-siteactions">
+                    <li>
+                        <br />
+                    </li>
+                </ul><a id="portal-logo" accesskey="1"
+                    href="http://downloads.openmicroscopy.org/"
+                    name="portal-logo"><img src="images/logo.jpg" alt=""
+                        title="" height="73" width="450" /></a>
+                <div id="portal-globalnav">
+                    <br />
+                </div>
+            </div>
+            <div id="portal-personaltools-wrapper">
+                <ul id="portal-personaltools" class="visualInline">
+                    <li>
+                        <br />
+                    </li>
+                </ul>
+            </div>
+        </div>
+        <div class="visualClear" id="clear-space-before-wrapper-table">
+            <!-- OME Banner - END -->
+            <!-- /#menu -->
+            <!-- <section id="content" class="body" style="margin-left:20px;"> <div class="entry-content"> -->
+            <h2>OMERO.figure @VERSION@</h2>
+            <ul>
+                <li>
+                    <p>Information on this release of OMERO.figure is in the <a
+                            href="@ANNOUCEMENT_URL@">release announcement</a>.
+                    </p>
+                </li>
 
-				<li>
-					<p>Full documentation is available as <a
-							href="http://will-moore.github.io/figure/">web documentation</a>.</p>
-				</li>
+                <li>
+                    <p>Full documentation is available as <a
+                            href="http://will-moore.github.io/figure/">web
+                            documentation</a>.</p>
+                </li>
 
-				<li>
-					<p>Source code and the latest development version can be found on <a
-							href="https://github.com/will-moore/figure">GitHub</a>.</p>
-				</li>
-			</ul>
-			<h2>Downloads</h2>
-			<div class="alt-table">
-				<table width="800" border="0" cellpadding="5">
-					<tbody>
-						<tr>
-							<th width="269">File</th>
-							<th width="85">Size</th>
-							<th width="271">File Name</th>
-							<th width="125">Checksum</th>
-						</tr>
-						<tr>
-							<td><a href="@FIGURE@"><img src="images/omero_figure.png"
-										alt="OMERO.figure Download" /></a></td>
-							<td align="center">@FIGURE_SIZE@</td>
-							<td>@FIGURE_BASE@</td>
-							<td align="center">@FIGURE_MD5@ (<a href="@FIGURE@.md5">MD5</a>)</td>
-						</tr>
-					</tbody>
-				</table>
-			</div>
-		</div><!-- /.entry-content -->
-		<!-- </section> -->
-		<!-- <footer id="contentinfo" class="body"> </footer> --><!-- /#contentinfo -->
-		<!-- OME Footer - Start -->
-		<div class="visualClear" id="clear-space-before-footer"><!-- --></div>
-		<div id="portal-footer">
-			<p>
-				<acronym title="Copyright">&copy;</acronym> 2000-2014 University of Dundee &amp;
-				Open Microscopy Environment. <a
-					href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
-					>Creative Commons Attribution 3.0 Unported License</a>
-			</p>
-			<p> OME source code is available under the <a
-					href="http://www.openmicroscopy.org/site/about/licensing">GNU General public
-					license</a> or through commercial license from <a
-					href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software"
-					>Glencoe Software</a>
-			</p>
-		</div>
-		<div class="visualClear">
-			<!-- OME Footer - END -->
-		</div>
-	</body>
+                <li>
+                    <p>Source code and the latest development version can be
+                        found on <a href="https://github.com/will-moore/figure"
+                            >GitHub</a>.</p>
+                </li>
+            </ul>
+            <h2>Downloads</h2>
+            <div class="alt-table">
+                <table width="800" border="0" cellpadding="5">
+                    <tbody>
+                        <tr>
+                            <th width="269">File</th>
+                            <th width="85">Size</th>
+                            <th width="271">File Name</th>
+                            <th width="125">Checksum</th>
+                        </tr>
+                        <tr>
+                            <td><a href="@FIGURE@"><img
+                                        src="images/omero_figure.png"
+                                        alt="OMERO.figure Download" /></a></td>
+                            <td align="center">@FIGURE_SIZE@</td>
+                            <td>@FIGURE_BASE@</td>
+                            <td align="center">@FIGURE_MD5@ (<a
+                                    href="@FIGURE@.md5">MD5</a>)</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div><!-- /.entry-content -->
+        <!-- </section> -->
+        <!-- <footer id="contentinfo" class="body"> </footer> --><!-- /#contentinfo -->
+        <!-- OME Footer - Start -->
+        <div class="visualClear" id="clear-space-before-footer"><!-- --></div>
+        <div id="portal-footer">
+            <p>
+                <acronym title="Copyright">&copy;</acronym> 2000-2014 University
+                of Dundee &amp; Open Microscopy Environment. <a
+                    href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
+                    >Creative Commons Attribution 3.0 Unported License</a>
+            </p>
+            <p> OME source code is available under the <a
+                    href="http://www.openmicroscopy.org/site/about/licensing"
+                    >GNU General public license</a> or through commercial
+                license from <a
+                    href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software"
+                    >Glencoe Software</a>
+            </p>
+        </div>
+        <div class="visualClear">
+            <!-- OME Footer - END -->
+        </div>
+    </body>
 </html>

--- a/figure_downloads.html
+++ b/figure_downloads.html
@@ -1,98 +1,116 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-        
-        <link rel="stylesheet" href="images/plonematch.css" type="text/css">
-        <meta charset="utf-8">
-          
-  
-      <meta name="tags" contents="OMERO.figure">
-  
-    <style type="text/css"></style><style>[touch-action="none"]{ -ms-touch-action: none; touch-action: none; }[touch-action="pan-x"]{ -ms-touch-action: pan-x; touch-action: pan-x; }[touch-action="pan-y"]{ -ms-touch-action: pan-y; touch-action: pan-y; }[touch-action="scroll"],[touch-action="pan-x pan-y"],[touch-action="pan-y pan-x"]{ -ms-touch-action: pan-x pan-y; touch-action: pan-x pan-y; }</style></head>
-    <body id="index" class="home">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 
+		<link rel="stylesheet" href="images/plonematch.css" type="text/css" />
+
+		<style type="text/css">
+			[touch-action = "none"]{
+				-ms-touch-action:none;
+				touch-action:none;
+			}
+			[touch-action = "pan-x"]{
+				-ms-touch-action:pan-x;
+				touch-action:pan-x;
+			}
+			[touch-action = "pan-y"]{
+				-ms-touch-action:pan-y;
+				touch-action:pan-y;
+			}
+			[touch-action = "scroll"],
+			[touch-action = "pan-x pan-y"],
+			[touch-action = "pan-y pan-x"]{
+				-ms-touch-action:pan-x pan-y;
+				touch-action:pan-x pan-y;
+			}</style>
+		<title></title>
+	</head>
+	<body id="index" class="home">
 		<!-- OME Banner - START -->
 		<div id="portal-top">
 			<div id="portal-header">
 				<ul id="portal-siteactions">
 					<li>
-						<br>
+						<br />
 					</li>
-				</ul><a id="portal-logo" accesskey="1" href="http://downloads.openmicroscopy.org/" name="portal-logo"><img src="images/logo.jpg" alt="" title="" height="73" width="450"></a>
-			  <div id="portal-globalnav">
-					<br>
+				</ul><a id="portal-logo" accesskey="1" href="http://downloads.openmicroscopy.org/"
+					name="portal-logo"><img src="images/logo.jpg" alt="" title="" height="73"
+						width="450" /></a>
+				<div id="portal-globalnav">
+					<br />
 				</div>
 			</div>
 			<div id="portal-personaltools-wrapper">
 				<ul id="portal-personaltools" class="visualInline">
 					<li>
-						<br>
+						<br />
 					</li>
 				</ul>
 			</div>
 		</div>
 		<div class="visualClear" id="clear-space-before-wrapper-table">
-		<!-- OME Banner - END -->
+			<!-- OME Banner - END -->
+			<!-- /#menu -->
+			<!-- <section id="content" class="body" style="margin-left:20px;"> <div class="entry-content"> -->
+			<h2>OMERO.figure @VERSION@</h2>
+			<ul>
+				<li>
+					<p>Information on this release of OMERO.figure is in the <a
+							href="@ANNOUCEMENT_URL@">release announcement</a>. </p>
+				</li>
 
-                                  <!-- /#menu -->
-<section id="content" class="body" style="margin-left:20px;">
+				<li>
+					<p>Full documentation is available as <a
+							href="http://will-moore.github.io/figure/">web documentation</a>.</p>
+				</li>
 
-<div class="entry-content">
-
-<h2>OMERO.figure @VERSION@</h2>
-
-<ul>
-<li>
-<p>Information on this release of OMERO.figure is in the <a href="@ANNOUCEMENT_URL@">release announcement</a>. </p>
-</li>
-
-<li>
-<p>Full documentation is available as <a href="http://will-moore.github.io/figure/">web documentation</a>.</p>
-</li>
-
-<li>
-<p>Source code and the latest development version can be found on <a href="https://github.com/will-moore/figure">GitHub</a>.</p>
-</li>
-</ul>
-
-<h2>Downloads</h2>
-
-<div class="alt-table">
-  <table width="800" border="0" cellpadding="5">
-    <tbody>
-      <tr>
-        <th width="269">File</th>
-        <th width="85">Size</th>
-        <th width="271">File Name</th>
-        <th width="125">Checksum</th>
-        </tr>
-      <tr>
-        <td><a href="@FIGURE@"><img src="images/omero_figure.png" alt="OMERO.figure Download" /></a></td>
-        <td align="center">@FIGURE_SIZE@</td>
-        <td>@FIGURE_BASE@</td>
-        <td align="center">@FIGURE_MD5@ (<a href="@FIGURE@.md5">MD5</a>)</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-  
-  </div><!-- /.entry-content -->
-</section>
-        <footer id="contentinfo" class="body">
-        </footer><!-- /#contentinfo -->
-
+				<li>
+					<p>Source code and the latest development version can be found on <a
+							href="https://github.com/will-moore/figure">GitHub</a>.</p>
+				</li>
+			</ul>
+			<h2>Downloads</h2>
+			<div class="alt-table">
+				<table width="800" border="0" cellpadding="5">
+					<tbody>
+						<tr>
+							<th width="269">File</th>
+							<th width="85">Size</th>
+							<th width="271">File Name</th>
+							<th width="125">Checksum</th>
+						</tr>
+						<tr>
+							<td><a href="@FIGURE@"><img src="images/omero_figure.png"
+										alt="OMERO.figure Download" /></a></td>
+							<td align="center">@FIGURE_SIZE@</td>
+							<td>@FIGURE_BASE@</td>
+							<td align="center">@FIGURE_MD5@ (<a href="@FIGURE@.md5">MD5</a>)</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+		</div><!-- /.entry-content -->
+		<!-- </section> -->
+		<!-- <footer id="contentinfo" class="body"> </footer> --><!-- /#contentinfo -->
 		<!-- OME Footer - Start -->
 		<div class="visualClear" id="clear-space-before-footer"><!-- --></div>
 		<div id="portal-footer">
 			<p>
-				<acronym title="Copyright">&copy;</acronym>
-				2000-2014
-				University of Dundee &amp; Open Microscopy Environment. <a href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing">Creative Commons Attribution 3.0 Unported License</a>
+				<acronym title="Copyright">&copy;</acronym> 2000-2014 University of Dundee &amp;
+				Open Microscopy Environment. <a
+					href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
+					>Creative Commons Attribution 3.0 Unported License</a>
 			</p>
-			<p>
-				OME source code is available under the <a href="http://www.openmicroscopy.org/site/about/licensing">GNU General public license</a> or through commercial license from <a href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software">Glencoe Software</a>
+			<p> OME source code is available under the <a
+					href="http://www.openmicroscopy.org/site/about/licensing">GNU General public
+					license</a> or through commercial license from <a
+					href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software"
+					>Glencoe Software</a>
 			</p>
 		</div>
 		<div class="visualClear">
-		<!-- OME Footer - END -->
-	
-</div></div></body></html>
+			<!-- OME Footer - END -->
+		</div>
+	</body>
+</html>

--- a/figure_downloads.html
+++ b/figure_downloads.html
@@ -76,7 +76,7 @@
             </ul>
             <h2>Downloads</h2>
             <div class="alt-table">
-                <table width="800" border="0" cellpadding="5">
+                <table width="800" border="0" cellpadding="5" summary="Downloads">
                     <tbody>
                         <tr>
                             <th width="269">File</th>

--- a/flimfit_downloads.html
+++ b/flimfit_downloads.html
@@ -110,7 +110,7 @@
                 <h2><a name="flimfit_50" id="flimfit_50"></a>FLIMfit downloads
                     for OMERO 5.0.x</h2>
                 <div class="alt-table">
-                    <table width="800" border="0" cellpadding="5">
+                    <table width="800" border="0" cellpadding="5" summary="FLIMfit for OMERO 5.0.x Downloads">
                         <tbody>
                             <tr>
                                 <th width="269">Clients</th>
@@ -135,7 +135,7 @@
                 <h2><a name="flimfit_44" id="flimfit_44"></a>FLIMfit downloads
                     for OMERO 4.4.x</h2>
                 <div class="alt-table">
-                    <table width="800" border="0" cellpadding="5">
+                    <table width="800" border="0" cellpadding="5"summary="FLIMfit for OMERO 4.4.x Downloads">
                         <tbody>
                             <tr>
                                 <th width="269">Clients</th>
@@ -159,7 +159,7 @@
                 </div>
                 <h2><a name="code" id="code"></a>Checking out the code</h2>
                 <div class="alt-table">
-                    <table width="278" border="0" cellpadding="5">
+                    <table width="278" border="0" cellpadding="5" summary="FLIMfit Source Code">
                         <tbody>
                             <tr>
                                 <th width="264">Source Code Links</th>

--- a/flimfit_downloads.html
+++ b/flimfit_downloads.html
@@ -51,9 +51,7 @@
         </div>
         <div class="visualClear" id="clear-space-before-wrapper-table">
             <!-- OME Banner - END -->
-            <!-- /#menu -->
-            <!-- <section id="content" class="body" style="margin-left:20px;">  -->
-            <div class="entry-content">
+        	<div class="entry-content" style="margin-left:20px;">
                 <h2>FLIMfit @VERSION@ Downloads</h2>
                 <p>
                     <strong><a href="#flimfit_50">OMERO
@@ -135,7 +133,7 @@
                 <h2><a name="flimfit_44" id="flimfit_44"></a>FLIMfit downloads
                     for OMERO 4.4.x</h2>
                 <div class="alt-table">
-                    <table width="800" border="0" cellpadding="5"summary="FLIMfit for OMERO 4.4.x Downloads">
+                    <table width="800" border="0" cellpadding="5" summary="FLIMfit for OMERO 4.4.x Downloads">
                         <tbody>
                             <tr>
                                 <th width="269">Clients</th>
@@ -186,10 +184,8 @@
                     </li>
                 </ul>
             </div><!-- /.entry-content -->
-            <!-- </section>  -->
-            <!-- <footer id="contentinfo" class="body">
-			</footer> --><!-- /#contentinfo -->
-            <!-- OME Footer - Start -->
+
+        	<!-- OME Footer - Start -->
             <div class="visualClear" id="clear-space-before-footer"
                 ><!-- --></div>
             <div id="portal-footer">

--- a/flimfit_downloads.html
+++ b/flimfit_downloads.html
@@ -1,152 +1,192 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 
-        <link rel="stylesheet" href="images/plonematch.css" type="text/css">
-        <meta charset="utf-8">
-
-
-      <meta name="tags" contents="flimfit">
-
-    <style type="text/css"></style><style>[touch-action="none"]{ -ms-touch-action: none; touch-action: none; }[touch-action="pan-x"]{ -ms-touch-action: pan-x; touch-action: pan-x; }[touch-action="pan-y"]{ -ms-touch-action: pan-y; touch-action: pan-y; }[touch-action="scroll"],[touch-action="pan-x pan-y"],[touch-action="pan-y pan-x"]{ -ms-touch-action: pan-x pan-y; touch-action: pan-x pan-y; }</style></head>
-    <body id="index" class="home">
-
+		<link rel="stylesheet" href="images/plonematch.css" type="text/css" />
+		<style type="text/css">
+			[touch-action = "none"]{
+				-ms-touch-action:none;
+				touch-action:none;
+			}
+			[touch-action = "pan-x"]{
+				-ms-touch-action:pan-x;
+				touch-action:pan-x;
+			}
+			[touch-action = "pan-y"]{
+				-ms-touch-action:pan-y;
+				touch-action:pan-y;
+			}
+			[touch-action = "scroll"],
+			[touch-action = "pan-x pan-y"],
+			[touch-action = "pan-y pan-x"]{
+				-ms-touch-action:pan-x pan-y;
+				touch-action:pan-x pan-y;
+			}</style>
+		<title>FLIMfit</title>
+	</head>
+	<body id="index" class="home">
 		<!-- OME Banner - START -->
 		<div id="portal-top">
 			<div id="portal-header">
 				<ul id="portal-siteactions">
 					<li>
-						<br>
+						<br />
 					</li>
-				</ul><a id="portal-logo" accesskey="1" href="http://downloads.openmicroscopy.org/" name="portal-logo"><img src="images/logo.jpg" alt="" title="" height="73" width="450"></a>
-			  <div id="portal-globalnav">
-					<br>
+				</ul><a id="portal-logo" accesskey="1" href="http://downloads.openmicroscopy.org/"
+					name="portal-logo"><img src="images/logo.jpg" alt="" title="" height="73"
+						width="450" /></a>
+				<div id="portal-globalnav">
+					<br />
 				</div>
 			</div>
 			<div id="portal-personaltools-wrapper">
 				<ul id="portal-personaltools" class="visualInline">
 					<li>
-						<br>
+						<br />
 					</li>
 				</ul>
 			</div>
 		</div>
 		<div class="visualClear" id="clear-space-before-wrapper-table">
-		<!-- OME Banner - END -->
+			<!-- OME Banner - END -->
+			<!-- /#menu -->
+			<!-- <section id="content" class="body" style="margin-left:20px;">  -->
+			<div class="entry-content">
+				<h2>FLIMfit @VERSION@ Downloads</h2>
+				<p>
+					<strong><a href="#flimfit_50">OMERO 5.0</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
+							href="#flimfit_44">OMERO 4.4</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#code"
+							>Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#previous">Previous
+							versions</a>
+					</strong></p>
+				<ul>
+					<li>
+						<p>Mac users, please note that in order to run FLIMfit you will need the
+							MATLAB Compiler Runtime (MCR) which enables the execution of compiled
+							MATLAB applications or components on computers that do not have MATLAB
+							installed. It can be downloaded from <a
+								href="http://www.mathworks.co.uk/products/compiler/mcr/">MATLAB
+								Compiler Runtime (MCR)</a>. The Windows Installer will automatically
+							install the MCR. </p>
+					</li>
 
-                                  <!-- /#menu -->
-<section id="content" class="body" style="margin-left:20px;">
-
-<div class="entry-content">
-
-<h2>FLIMfit @VERSION@ Downloads</h2>
-
-<p>
-  <strong><a href="#flimfit_50">OMERO 5.0</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#flimfit_44">OMERO 4.4</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#code">Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#previous">Previous versions</a> </strong></p>
-
-<ul>
-<li>
-<p>Mac users, please note that in order to run FLIMfit you will need the MATLAB Compiler Runtime (MCR) which enables the execution of compiled MATLAB applications or components on computers that do not have MATLAB installed. It can be downloaded from <a href="http://www.mathworks.co.uk/products/compiler/mcr/">MATLAB Compiler Runtime (MCR)</a>. The Windows Installer will automatically install the MCR. </p>
-</li>
-
-<li>
-<p>Please explicitly acknowledge "the FLIMfit software tool developed at Imperial College London" in any publications benefitting from its use.  In order for us to monitor the use of FLIMfit and to support its ongoing development, we would be grateful if you could send details of any such publications (particularly DOIs of published papers) to: <a href="mailto:FLIMfit@imperial.ac.uk">FLIMfit@imperial.ac.uk</a>.
-</p>
-<p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the <a href="http://www.gnu.org/copyleft/gpl.html">GNU General Public License</a> for more details.
-</p>
-</li>
-<li>
-<p>Users who intend to use FLIMfit without OMERO can download either version (for 4.4.x or 5.0.x) as there will be no difference in stand-alone mode.</p>
-</li>
-
-</li>
-<li>
-<p>Windows users please note that there is currently no pre-compiled binary of 4.6.4 for OMERO 5.0.x due to reported problems connecting to 5.0.0 servers from FLIMfit on some Windows variants. It is, however, possible to use FLIMfit from the MATLAB source on GitHub by following the link below.</p>
-</li>
-</ul>
-
-
-
-<h2><a name="flimfit_50" id="flimfit_50"></a>FLIMfit downloads for OMERO 5.0.x</h2>
-<div class="alt-table">
-  <table width="800" border="0" cellpadding="5">
-    <tbody>
-      <tr>
-        <th width="269">Clients</th>
-        <th width="85">Size</th>
-        <th width="271">File Name</th>
-        <th width="125">Checksum</th>
-        </tr>
-      <tr>
-        <td><a href="@FLIMFIT_50_MAC@"><img src="images/flimfit_mac.png" alt="Mac OS X Client Download" /></a></td>
-        <td align="center">@FLIMFIT_50_MAC_SIZE@</td>
-        <td>@FLIMFIT_50_MAC_BASE@</td>
-        <td align="center">@FLIMFIT_50_MAC_MD5@ (<a href="@FLIMFIT_50_MAC@.md5">MD5</a>)</td>
-        </tr>
-    </tbody>
-  </table>
-</div>
-
-<h2><a name="flimfit_44" id="flimfit_44"></a>FLIMfit downloads for OMERO 4.4.x</h2>
-<div class="alt-table">
-  <table width="800" border="0" cellpadding="5">
-    <tbody>
-      <tr>
-        <th width="269">Clients</th>
-        <th width="85">Size</th>
-        <th width="271">File Name</th>
-        <th width="125">Checksum</th>
-        </tr>
-      <tr>
-        <td><a href="@FLIMFIT_44_MAC@"><img src="images/flimfit_mac.png" alt="Mac OS X Client Download" /></a></td>
-        <td align="center">@FLIMFIT_44_MAC_SIZE@</td>
-        <td>@FLIMFIT_44_MAC_BASE@</td>
-        <td align="center">@FLIMFIT_44_MAC_MD5@ (<a href="@FLIMFIT_44_MAC@.md5">MD5</a>)</td>
-        </tr>
-    </tbody>
-  </table>
-</div>
-
-<h2><a name="code" id="code"></a>Checking out the code</h2>
-
-<div class="alt-table">
-<table width="278" border="0" cellpadding="5">
-  <tbody>
-    <tr>
-      <th width="264">Source Code Links</th>
-    </tr>
-    <tr>
-      <td><a href="https://github.com/openmicroscopy/Imperial-FLIMFit" target="_blank"><img src="images/github_rep_link.png" alt="GitHub Repository Link" /></a></td>
-    </tr>
-  </tbody>
-</table>
-</div>
-
-<h2><a name="previous" id="previous"></a>Previous versions</h2>
-
-<ul>
-  <li>
-<p>We recommend that you always use the most recent release version of the FLIMfit software, but if you need to use a previous version,  they are all available from the main <a href="http://downloads.openmicroscopy.org/flimfit/?C=M;O=D">downloads folder</a>.</p>
-  </li>
-</ul>
-
-  </div><!-- /.entry-content -->
-</section>
-        <footer id="contentinfo" class="body">
-        </footer><!-- /#contentinfo -->
-
-		<!-- OME Footer - Start -->
-		<div class="visualClear" id="clear-space-before-footer"><!-- --></div>
-		<div id="portal-footer">
-			<p>
-				<acronym title="Copyright">&copy;</acronym>
-				2000-2014
-				University of Dundee &amp; Open Microscopy Environment. <a href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing">Creative Commons Attribution 3.0 Unported License</a>
-			</p>
-			<p>
-				OME source code is available under the <a href="http://www.openmicroscopy.org/site/about/licensing">GNU General public license</a> or through commercial license from <a href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software">Glencoe Software</a>
-			</p>
+					<li>
+						<p>Please explicitly acknowledge "the FLIMfit software tool developed at
+							Imperial College London" in any publications benefitting from its use.
+							In order for us to monitor the use of FLIMfit and to support its ongoing
+							development, we would be grateful if you could send details of any such
+							publications (particularly DOIs of published papers) to: <a
+								href="mailto:FLIMfit@imperial.ac.uk">FLIMfit@imperial.ac.uk</a>. </p>
+						<p>This program is distributed in the hope that it will be useful, but
+							WITHOUT ANY WARRANTY; without even the implied warranty of
+							MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the <a
+								href="http://www.gnu.org/copyleft/gpl.html">GNU General Public
+								License</a> for more details. </p>
+					</li>
+					<li>
+						<p>Users who intend to use FLIMfit without OMERO can download either version
+							(for 4.4.x or 5.0.x) as there will be no difference in stand-alone
+							mode.</p>
+					</li>
+					<li>
+						<p>Windows users please note that there is currently no pre-compiled binary
+							of 4.6.4 for OMERO 5.0.x due to reported problems connecting to 5.0.0
+							servers from FLIMfit on some Windows variants. It is, however, possible
+							to use FLIMfit from the MATLAB source on GitHub by following the link
+							below.</p>
+					</li>
+				</ul>
+				<h2><a name="flimfit_50" id="flimfit_50"></a>FLIMfit downloads for OMERO 5.0.x</h2>
+				<div class="alt-table">
+					<table width="800" border="0" cellpadding="5">
+						<tbody>
+							<tr>
+								<th width="269">Clients</th>
+								<th width="85">Size</th>
+								<th width="271">File Name</th>
+								<th width="125">Checksum</th>
+							</tr>
+							<tr>
+								<td><a href="@FLIMFIT_50_MAC@"><img src="images/flimfit_mac.png"
+											alt="Mac OS X Client Download" /></a></td>
+								<td align="center">@FLIMFIT_50_MAC_SIZE@</td>
+								<td>@FLIMFIT_50_MAC_BASE@</td>
+								<td align="center">@FLIMFIT_50_MAC_MD5@ (<a
+										href="@FLIMFIT_50_MAC@.md5">MD5</a>)</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<h2><a name="flimfit_44" id="flimfit_44"></a>FLIMfit downloads for OMERO 4.4.x</h2>
+				<div class="alt-table">
+					<table width="800" border="0" cellpadding="5">
+						<tbody>
+							<tr>
+								<th width="269">Clients</th>
+								<th width="85">Size</th>
+								<th width="271">File Name</th>
+								<th width="125">Checksum</th>
+							</tr>
+							<tr>
+								<td><a href="@FLIMFIT_44_MAC@"><img src="images/flimfit_mac.png"
+											alt="Mac OS X Client Download" /></a></td>
+								<td align="center">@FLIMFIT_44_MAC_SIZE@</td>
+								<td>@FLIMFIT_44_MAC_BASE@</td>
+								<td align="center">@FLIMFIT_44_MAC_MD5@ (<a
+										href="@FLIMFIT_44_MAC@.md5">MD5</a>)</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<h2><a name="code" id="code"></a>Checking out the code</h2>
+				<div class="alt-table">
+					<table width="278" border="0" cellpadding="5">
+						<tbody>
+							<tr>
+								<th width="264">Source Code Links</th>
+							</tr>
+							<tr>
+								<td><a href="https://github.com/openmicroscopy/Imperial-FLIMFit"
+										target="_blank"><img src="images/github_rep_link.png"
+											alt="GitHub Repository Link" /></a></td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<h2><a name="previous" id="previous"></a>Previous versions</h2>
+				<ul>
+					<li>
+						<p>We recommend that you always use the most recent release version of the
+							FLIMfit software, but if you need to use a previous version, they are
+							all available from the main <a
+								href="http://downloads.openmicroscopy.org/flimfit/?C=M;O=D"
+								>downloads folder</a>.</p>
+					</li>
+				</ul>
+			</div><!-- /.entry-content -->
+			<!-- </section>  -->
+			<!-- <footer id="contentinfo" class="body">
+			</footer> --><!-- /#contentinfo -->
+			<!-- OME Footer - Start -->
+			<div class="visualClear" id="clear-space-before-footer"><!-- --></div>
+			<div id="portal-footer">
+				<p>
+					<acronym title="Copyright">&copy;</acronym> 2000-2014 University of Dundee &amp;
+					Open Microscopy Environment. <a
+						href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
+						>Creative Commons Attribution 3.0 Unported License</a>
+				</p>
+				<p> OME source code is available under the <a
+						href="http://www.openmicroscopy.org/site/about/licensing">GNU General public
+						license</a> or through commercial license from <a
+						href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software"
+						>Glencoe Software</a>
+				</p>
+			</div>
+			<div class="visualClear">
+				<!-- OME Footer - END -->
+			</div>
 		</div>
-		<div class="visualClear">
-		<!-- OME Footer - END -->
-
-</div></div></body></html>
+	</body>
+</html>

--- a/flimfit_downloads.html
+++ b/flimfit_downloads.html
@@ -1,192 +1,215 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
-	<head>
-		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 
-		<link rel="stylesheet" href="images/plonematch.css" type="text/css" />
-		<style type="text/css">
-			[touch-action = "none"]{
-				-ms-touch-action:none;
-				touch-action:none;
-			}
-			[touch-action = "pan-x"]{
-				-ms-touch-action:pan-x;
-				touch-action:pan-x;
-			}
-			[touch-action = "pan-y"]{
-				-ms-touch-action:pan-y;
-				touch-action:pan-y;
-			}
-			[touch-action = "scroll"],
-			[touch-action = "pan-x pan-y"],
-			[touch-action = "pan-y pan-x"]{
-				-ms-touch-action:pan-x pan-y;
-				touch-action:pan-x pan-y;
-			}</style>
-		<title>FLIMfit</title>
-	</head>
-	<body id="index" class="home">
-		<!-- OME Banner - START -->
-		<div id="portal-top">
-			<div id="portal-header">
-				<ul id="portal-siteactions">
-					<li>
-						<br />
-					</li>
-				</ul><a id="portal-logo" accesskey="1" href="http://downloads.openmicroscopy.org/"
-					name="portal-logo"><img src="images/logo.jpg" alt="" title="" height="73"
-						width="450" /></a>
-				<div id="portal-globalnav">
-					<br />
-				</div>
-			</div>
-			<div id="portal-personaltools-wrapper">
-				<ul id="portal-personaltools" class="visualInline">
-					<li>
-						<br />
-					</li>
-				</ul>
-			</div>
-		</div>
-		<div class="visualClear" id="clear-space-before-wrapper-table">
-			<!-- OME Banner - END -->
-			<!-- /#menu -->
-			<!-- <section id="content" class="body" style="margin-left:20px;">  -->
-			<div class="entry-content">
-				<h2>FLIMfit @VERSION@ Downloads</h2>
-				<p>
-					<strong><a href="#flimfit_50">OMERO 5.0</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
-							href="#flimfit_44">OMERO 4.4</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#code"
-							>Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#previous">Previous
-							versions</a>
-					</strong></p>
-				<ul>
-					<li>
-						<p>Mac users, please note that in order to run FLIMfit you will need the
-							MATLAB Compiler Runtime (MCR) which enables the execution of compiled
-							MATLAB applications or components on computers that do not have MATLAB
-							installed. It can be downloaded from <a
-								href="http://www.mathworks.co.uk/products/compiler/mcr/">MATLAB
-								Compiler Runtime (MCR)</a>. The Windows Installer will automatically
-							install the MCR. </p>
-					</li>
+        <link rel="stylesheet" href="images/plonematch.css" type="text/css" />
+        <style type="text/css">
+            [touch-action = "none"]{
+                -ms-touch-action:none;
+                touch-action:none;
+            }
+            [touch-action = "pan-x"]{
+                -ms-touch-action:pan-x;
+                touch-action:pan-x;
+            }
+            [touch-action = "pan-y"]{
+                -ms-touch-action:pan-y;
+                touch-action:pan-y;
+            }
+            [touch-action = "scroll"],
+            [touch-action = "pan-x pan-y"],
+            [touch-action = "pan-y pan-x"]{
+                -ms-touch-action:pan-x pan-y;
+                touch-action:pan-x pan-y;
+            }</style>
+        <title>FLIMfit</title>
+    </head>
+    <body id="index" class="home">
+        <!-- OME Banner - START -->
+        <div id="portal-top">
+            <div id="portal-header">
+                <ul id="portal-siteactions">
+                    <li>
+                        <br />
+                    </li>
+                </ul><a id="portal-logo" accesskey="1"
+                    href="http://downloads.openmicroscopy.org/"
+                    name="portal-logo"><img src="images/logo.jpg" alt=""
+                        title="" height="73" width="450" /></a>
+                <div id="portal-globalnav">
+                    <br />
+                </div>
+            </div>
+            <div id="portal-personaltools-wrapper">
+                <ul id="portal-personaltools" class="visualInline">
+                    <li>
+                        <br />
+                    </li>
+                </ul>
+            </div>
+        </div>
+        <div class="visualClear" id="clear-space-before-wrapper-table">
+            <!-- OME Banner - END -->
+            <!-- /#menu -->
+            <!-- <section id="content" class="body" style="margin-left:20px;">  -->
+            <div class="entry-content">
+                <h2>FLIMfit @VERSION@ Downloads</h2>
+                <p>
+                    <strong><a href="#flimfit_50">OMERO
+                            5.0</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
+                            href="#flimfit_44">OMERO
+                            4.4</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#code"
+                            >Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
+                            href="#previous">Previous versions</a>
+                    </strong></p>
+                <ul>
+                    <li>
+                        <p>Mac users, please note that in order to run FLIMfit
+                            you will need the MATLAB Compiler Runtime (MCR)
+                            which enables the execution of compiled MATLAB
+                            applications or components on computers that do not
+                            have MATLAB installed. It can be downloaded from <a
+                                href="http://www.mathworks.co.uk/products/compiler/mcr/"
+                                >MATLAB Compiler Runtime (MCR)</a>. The Windows
+                            Installer will automatically install the MCR. </p>
+                    </li>
 
-					<li>
-						<p>Please explicitly acknowledge "the FLIMfit software tool developed at
-							Imperial College London" in any publications benefitting from its use.
-							In order for us to monitor the use of FLIMfit and to support its ongoing
-							development, we would be grateful if you could send details of any such
-							publications (particularly DOIs of published papers) to: <a
-								href="mailto:FLIMfit@imperial.ac.uk">FLIMfit@imperial.ac.uk</a>. </p>
-						<p>This program is distributed in the hope that it will be useful, but
-							WITHOUT ANY WARRANTY; without even the implied warranty of
-							MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the <a
-								href="http://www.gnu.org/copyleft/gpl.html">GNU General Public
-								License</a> for more details. </p>
-					</li>
-					<li>
-						<p>Users who intend to use FLIMfit without OMERO can download either version
-							(for 4.4.x or 5.0.x) as there will be no difference in stand-alone
-							mode.</p>
-					</li>
-					<li>
-						<p>Windows users please note that there is currently no pre-compiled binary
-							of 4.6.4 for OMERO 5.0.x due to reported problems connecting to 5.0.0
-							servers from FLIMfit on some Windows variants. It is, however, possible
-							to use FLIMfit from the MATLAB source on GitHub by following the link
-							below.</p>
-					</li>
-				</ul>
-				<h2><a name="flimfit_50" id="flimfit_50"></a>FLIMfit downloads for OMERO 5.0.x</h2>
-				<div class="alt-table">
-					<table width="800" border="0" cellpadding="5">
-						<tbody>
-							<tr>
-								<th width="269">Clients</th>
-								<th width="85">Size</th>
-								<th width="271">File Name</th>
-								<th width="125">Checksum</th>
-							</tr>
-							<tr>
-								<td><a href="@FLIMFIT_50_MAC@"><img src="images/flimfit_mac.png"
-											alt="Mac OS X Client Download" /></a></td>
-								<td align="center">@FLIMFIT_50_MAC_SIZE@</td>
-								<td>@FLIMFIT_50_MAC_BASE@</td>
-								<td align="center">@FLIMFIT_50_MAC_MD5@ (<a
-										href="@FLIMFIT_50_MAC@.md5">MD5</a>)</td>
-							</tr>
-						</tbody>
-					</table>
-				</div>
-				<h2><a name="flimfit_44" id="flimfit_44"></a>FLIMfit downloads for OMERO 4.4.x</h2>
-				<div class="alt-table">
-					<table width="800" border="0" cellpadding="5">
-						<tbody>
-							<tr>
-								<th width="269">Clients</th>
-								<th width="85">Size</th>
-								<th width="271">File Name</th>
-								<th width="125">Checksum</th>
-							</tr>
-							<tr>
-								<td><a href="@FLIMFIT_44_MAC@"><img src="images/flimfit_mac.png"
-											alt="Mac OS X Client Download" /></a></td>
-								<td align="center">@FLIMFIT_44_MAC_SIZE@</td>
-								<td>@FLIMFIT_44_MAC_BASE@</td>
-								<td align="center">@FLIMFIT_44_MAC_MD5@ (<a
-										href="@FLIMFIT_44_MAC@.md5">MD5</a>)</td>
-							</tr>
-						</tbody>
-					</table>
-				</div>
-				<h2><a name="code" id="code"></a>Checking out the code</h2>
-				<div class="alt-table">
-					<table width="278" border="0" cellpadding="5">
-						<tbody>
-							<tr>
-								<th width="264">Source Code Links</th>
-							</tr>
-							<tr>
-								<td><a href="https://github.com/openmicroscopy/Imperial-FLIMFit"
-										target="_blank"><img src="images/github_rep_link.png"
-											alt="GitHub Repository Link" /></a></td>
-							</tr>
-						</tbody>
-					</table>
-				</div>
-				<h2><a name="previous" id="previous"></a>Previous versions</h2>
-				<ul>
-					<li>
-						<p>We recommend that you always use the most recent release version of the
-							FLIMfit software, but if you need to use a previous version, they are
-							all available from the main <a
-								href="http://downloads.openmicroscopy.org/flimfit/?C=M;O=D"
-								>downloads folder</a>.</p>
-					</li>
-				</ul>
-			</div><!-- /.entry-content -->
-			<!-- </section>  -->
-			<!-- <footer id="contentinfo" class="body">
+                    <li>
+                        <p>Please explicitly acknowledge "the FLIMfit software
+                            tool developed at Imperial College London" in any
+                            publications benefitting from its use. In order for
+                            us to monitor the use of FLIMfit and to support its
+                            ongoing development, we would be grateful if you
+                            could send details of any such publications
+                            (particularly DOIs of published papers) to: <a
+                                href="mailto:FLIMfit@imperial.ac.uk"
+                                >FLIMfit@imperial.ac.uk</a>. </p>
+                        <p>This program is distributed in the hope that it will
+                            be useful, but WITHOUT ANY WARRANTY; without even
+                            the implied warranty of MERCHANTABILITY or FITNESS
+                            FOR A PARTICULAR PURPOSE. See the <a
+                                href="http://www.gnu.org/copyleft/gpl.html">GNU
+                                General Public License</a> for more details.
+                        </p>
+                    </li>
+                    <li>
+                        <p>Users who intend to use FLIMfit without OMERO can
+                            download either version (for 4.4.x or 5.0.x) as
+                            there will be no difference in stand-alone mode.</p>
+                    </li>
+                    <li>
+                        <p>Windows users please note that there is currently no
+                            pre-compiled binary of 4.6.4 for OMERO 5.0.x due to
+                            reported problems connecting to 5.0.0 servers from
+                            FLIMfit on some Windows variants. It is, however,
+                            possible to use FLIMfit from the MATLAB source on
+                            GitHub by following the link below.</p>
+                    </li>
+                </ul>
+                <h2><a name="flimfit_50" id="flimfit_50"></a>FLIMfit downloads
+                    for OMERO 5.0.x</h2>
+                <div class="alt-table">
+                    <table width="800" border="0" cellpadding="5">
+                        <tbody>
+                            <tr>
+                                <th width="269">Clients</th>
+                                <th width="85">Size</th>
+                                <th width="271">File Name</th>
+                                <th width="125">Checksum</th>
+                            </tr>
+                            <tr>
+                                <td><a href="@FLIMFIT_50_MAC@"><img
+                                        src="images/flimfit_mac.png"
+                                        alt="Mac OS X Client Download"
+                                     /></a></td>
+                                <td align="center">@FLIMFIT_50_MAC_SIZE@</td>
+                                <td>@FLIMFIT_50_MAC_BASE@</td>
+                                <td align="center">@FLIMFIT_50_MAC_MD5@ (<a
+                                        href="@FLIMFIT_50_MAC@.md5"
+                                    >MD5</a>)</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <h2><a name="flimfit_44" id="flimfit_44"></a>FLIMfit downloads
+                    for OMERO 4.4.x</h2>
+                <div class="alt-table">
+                    <table width="800" border="0" cellpadding="5">
+                        <tbody>
+                            <tr>
+                                <th width="269">Clients</th>
+                                <th width="85">Size</th>
+                                <th width="271">File Name</th>
+                                <th width="125">Checksum</th>
+                            </tr>
+                            <tr>
+                                <td><a href="@FLIMFIT_44_MAC@"><img
+                                        src="images/flimfit_mac.png"
+                                        alt="Mac OS X Client Download"
+                                     /></a></td>
+                                <td align="center">@FLIMFIT_44_MAC_SIZE@</td>
+                                <td>@FLIMFIT_44_MAC_BASE@</td>
+                                <td align="center">@FLIMFIT_44_MAC_MD5@ (<a
+                                        href="@FLIMFIT_44_MAC@.md5"
+                                    >MD5</a>)</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <h2><a name="code" id="code"></a>Checking out the code</h2>
+                <div class="alt-table">
+                    <table width="278" border="0" cellpadding="5">
+                        <tbody>
+                            <tr>
+                                <th width="264">Source Code Links</th>
+                            </tr>
+                            <tr>
+                                <td><a
+                                        href="https://github.com/openmicroscopy/Imperial-FLIMFit"
+                                        target="_blank"><img
+                                        src="images/github_rep_link.png"
+                                        alt="GitHub Repository Link" /></a></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <h2><a name="previous" id="previous"></a>Previous versions</h2>
+                <ul>
+                    <li>
+                        <p>We recommend that you always use the most recent
+                            release version of the FLIMfit software, but if you
+                            need to use a previous version, they are all
+                            available from the main <a
+                                href="http://downloads.openmicroscopy.org/flimfit/?C=M;O=D"
+                                >downloads folder</a>.</p>
+                    </li>
+                </ul>
+            </div><!-- /.entry-content -->
+            <!-- </section>  -->
+            <!-- <footer id="contentinfo" class="body">
 			</footer> --><!-- /#contentinfo -->
-			<!-- OME Footer - Start -->
-			<div class="visualClear" id="clear-space-before-footer"><!-- --></div>
-			<div id="portal-footer">
-				<p>
-					<acronym title="Copyright">&copy;</acronym> 2000-2014 University of Dundee &amp;
-					Open Microscopy Environment. <a
-						href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
-						>Creative Commons Attribution 3.0 Unported License</a>
-				</p>
-				<p> OME source code is available under the <a
-						href="http://www.openmicroscopy.org/site/about/licensing">GNU General public
-						license</a> or through commercial license from <a
-						href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software"
-						>Glencoe Software</a>
-				</p>
-			</div>
-			<div class="visualClear">
-				<!-- OME Footer - END -->
-			</div>
-		</div>
-	</body>
+            <!-- OME Footer - Start -->
+            <div class="visualClear" id="clear-space-before-footer"
+                ><!-- --></div>
+            <div id="portal-footer">
+                <p>
+                    <acronym title="Copyright">&copy;</acronym> 2000-2014
+                    University of Dundee &amp; Open Microscopy Environment. <a
+                        href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
+                        >Creative Commons Attribution 3.0 Unported License</a>
+                </p>
+                <p> OME source code is available under the <a
+                        href="http://www.openmicroscopy.org/site/about/licensing"
+                        >GNU General public license</a> or through commercial
+                    license from <a
+                        href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software"
+                        >Glencoe Software</a>
+                </p>
+            </div>
+            <div class="visualClear">
+                <!-- OME Footer - END -->
+            </div>
+        </div>
+    </body>
 </html>

--- a/images/flimfit_downloads.html
+++ b/images/flimfit_downloads.html
@@ -81,7 +81,7 @@
                 <h2><a name="flimfit_50" id="flimfit_50"></a>FLIMFit downloads
                     for OME 5.0.x</h2>
                 <div class="alt-table">
-                    <table width="800" border="0" cellpadding="5">
+                    <table width="800" border="0" cellpadding="5" summary="FLIMfit for OMERO 5.0.x Downloads">
                         <tbody>
                             <tr>
                                 <th width="269">Clients</th>
@@ -117,7 +117,7 @@
                 <h2><a name="flimfit_44" id="flimfit_44"></a>FLIMFit downloads
                     for OME 4.4.x</h2>
                 <div class="alt-table">
-                    <table width="800" border="0" cellpadding="5">
+                    <table width="800" border="0" cellpadding="5" summary="FLIMfit for OMERO 4.4.x Downloads">
                         <tbody>
                             <tr>
                                 <th width="269">Clients</th>

--- a/images/flimfit_downloads.html
+++ b/images/flimfit_downloads.html
@@ -1,138 +1,170 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-        
-        <link rel="stylesheet" href="images/plonematch.css" type="text/css">
-        <meta charset="utf-8">
-          
-  
-      <meta name="tags" contents="flimfit">
-  
-    <style type="text/css"></style><style>[touch-action="none"]{ -ms-touch-action: none; touch-action: none; }[touch-action="pan-x"]{ -ms-touch-action: pan-x; touch-action: pan-x; }[touch-action="pan-y"]{ -ms-touch-action: pan-y; touch-action: pan-y; }[touch-action="scroll"],[touch-action="pan-x pan-y"],[touch-action="pan-y pan-x"]{ -ms-touch-action: pan-x pan-y; touch-action: pan-x pan-y; }</style></head>
-    <body id="index" class="home">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 
+		<link rel="stylesheet" href="images/plonematch.css" type="text/css" />
+		<style type="text/css">
+			[touch-action = "none"]{
+				-ms-touch-action:none;
+				touch-action:none;
+			}
+			[touch-action = "pan-x"]{
+				-ms-touch-action:pan-x;
+				touch-action:pan-x;
+			}
+			[touch-action = "pan-y"]{
+				-ms-touch-action:pan-y;
+				touch-action:pan-y;
+			}
+			[touch-action = "scroll"],
+			[touch-action = "pan-x pan-y"],
+			[touch-action = "pan-y pan-x"]{
+				-ms-touch-action:pan-x pan-y;
+				touch-action:pan-x pan-y;
+			}</style>
+		<title></title>
+	</head>
+	<body id="index" class="home">
 		<!-- OME Banner - START -->
 		<div id="portal-top">
 			<div id="portal-header">
 				<ul id="portal-siteactions">
 					<li>
-						<br>
+						<br />
 					</li>
-				</ul><a id="portal-logo" accesskey="1" href="http://downloads.openmicroscopy.org/" name="portal-logo"><img src="images/logo.jpg" alt="" title="" height="73" width="450"></a>
-			  <div id="portal-globalnav">
-					<br>
+				</ul><a id="portal-logo" accesskey="1" href="http://downloads.openmicroscopy.org/"
+					name="portal-logo"><img src="images/logo.jpg" alt="" title="" height="73"
+						width="450" /></a>
+				<div id="portal-globalnav">
+					<br />
 				</div>
 			</div>
 			<div id="portal-personaltools-wrapper">
 				<ul id="portal-personaltools" class="visualInline">
 					<li>
-						<br>
+						<br />
 					</li>
 				</ul>
 			</div>
 		</div>
 		<div class="visualClear" id="clear-space-before-wrapper-table">
-		<!-- OME Banner - END -->
+			<!-- OME Banner - END -->
+			<!-- /#menu -->
+			<!-- <section id="content" class="body" style="margin-left:20px;"> -->
+			<div class="entry-content">
+				<h2>FLIMFit @VERSION@ Downloads</h2>
+				<p>
+					<strong><a href="#flimfit_50">OME 5.0</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
+							href="#flimfit_44">OME 4.4</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#legacy"
+							>Legacy</a>
+					</strong></p>
+				<ul>
 
-                                  <!-- /#menu -->
-<section id="content" class="body" style="margin-left:20px;">
-
-<div class="entry-content">
-
-<h2>FLIMFit @VERSION@ Downloads</h2>
-
-<p>
-  <strong><a href="#flimfit_50">OME 5.0</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#flimfit_44">OME 4.4</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#legacy">Legacy</a> </strong></p>
-
-<ul>
-
-<li>
-<p>Full documentation is available as <a href="@DOC_URL@">web documentation</a>  or
-<a href="@DOC@">PDF documentation</a> and there are user guides for the clients on our <a href="http://help.openmicroscopy.org">Help website</a></p>
-</li>
-<li>
-<p>To use the compiled version below, you will need to download the MATLAB
-	MCR corresponding to your system.</p>
-</li>
-</ul>
-
-<h2><a name="flimfit_50" id="flimfit_50"></a>FLIMFit downloads for OME 5.0.x</h2>
-<div class="alt-table">
-  <table width="800" border="0" cellpadding="5">
-    <tbody>
-      <tr>
-        <th width="269">Clients</th>
-        <th width="85">Size</th>
-        <th width="271">File Name</th>
-        <th width="125">Checksum</th>
-        </tr>
-      <tr>
-        <td><a href="@FLIMFIT_50_WIN@"><img src="images/windows_download.png" alt="Windows Client Download" /></a></td>
-        <td align="center">@FLIMFIT_50_WIN_SIZE@</td>
-        <td>@FLIMFIT_50_WIN_BASE@</td>
-        <td align="center">@FLIMFIT_50_WIN_MD5@ (<a href="@FLIMFIT_50_WIN@.md5">MD5</a>)</td>
-      </tr>
-      <tr>
-        <td><a href="@FLIMFIT_50_MAC@"><img src="images/mac_download.png" alt="Mac OS X Client Download" /></a></td>
-        <td align="center">@FLIMFIT_50_MAC_SIZE@</td>
-        <td>@FLIMFIT_50_MAC_BASE@</td>
-        <td align="center">@FLIMFIT_50_MAC_MD5@ (<a href="@FLIMFIT_50_MAC@.md5">MD5</a>)</td>
-        </tr>
-    </tbody>
-  </table>
-</div>
-
-<h2><a name="flimfit_44" id="flimfit_44"></a>FLIMFit downloads for OME 4.4.x</h2>
-<div class="alt-table">
-  <table width="800" border="0" cellpadding="5">
-    <tbody>
-      <tr>
-        <th width="269">Clients</th>
-        <th width="85">Size</th>
-        <th width="271">File Name</th>
-        <th width="125">Checksum</th>
-        </tr>
-      <tr>
-        <td><a href="@FLIMFIT_44_WIN@"><img src="images/windows_download.png" alt="Windows Client Download" /></a></td>
-        <td align="center">@FLIMFIT_44_WIN_SIZE@</td>
-        <td>@FLIMFIT_44_WIN_BASE@</td>
-        <td align="center">@FLIMFIT_44_WIN_MD5@ (<a href="@FLIMFIT_44_WIN@.md5">MD5</a>)</td>
-      </tr>
-      <tr>
-        <td><a href="@FLIMFIT_44_MAC@"><img src="images/mac_download.png" alt="Mac OS X Client Download" /></a></td>
-        <td align="center">@FLIMFIT_44_MAC_SIZE@</td>
-        <td>@FLIMFIT_44_MAC_BASE@</td>
-        <td align="center">@FLIMFIT_44_MAC_MD5@ (<a href="@FLIMFIT_44_MAC@.md5">MD5</a>)</td>
-        </tr>
-    </tbody>
-  </table>
-</div>
-
-<h2><a name="legacy" id="legacy"></a>Legacy versions</h2>
-
-<ul>
-  <li>
-<p>We recommend that you always use the most recent release version of the OMERO software, but if you need to use a previous version,  they are all available from the main <a href="http://downloads.openmicroscopy.org/flimfit/?C=M;O=D">downloads folder</a></p>
-  </li>
-</ul>
-  
-  </div><!-- /.entry-content -->
-</section>
-        <footer id="contentinfo" class="body">
-        </footer><!-- /#contentinfo -->
-
-		<!-- OME Footer - Start -->
-		<div class="visualClear" id="clear-space-before-footer"><!-- --></div>
-		<div id="portal-footer">
-			<p>
-				<acronym title="Copyright">&copy;</acronym>
-				2000-2013
-				University of Dundee &amp; Open Microscopy Environment. <a href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing">Creative Commons Attribution 3.0 Unported License</a>
-			</p>
-			<p>
-				OME source code is available under the <a href="http://www.openmicroscopy.org/site/about/licensing">GNU General public license</a> or through commercial license from <a href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software">Glencoe Software</a>
-			</p>
+					<li>
+						<p>Full documentation is available as <a href="@DOC_URL@">web
+								documentation</a> or <a href="@DOC@">PDF documentation</a> and there
+							are user guides for the clients on our <a
+								href="http://help.openmicroscopy.org">Help website</a></p>
+					</li>
+					<li>
+						<p>To use the compiled version below, you will need to download the MATLAB
+							MCR corresponding to your system.</p>
+					</li>
+				</ul>
+				<h2><a name="flimfit_50" id="flimfit_50"></a>FLIMFit downloads for OME 5.0.x</h2>
+				<div class="alt-table">
+					<table width="800" border="0" cellpadding="5">
+						<tbody>
+							<tr>
+								<th width="269">Clients</th>
+								<th width="85">Size</th>
+								<th width="271">File Name</th>
+								<th width="125">Checksum</th>
+							</tr>
+							<tr>
+								<td><a href="@FLIMFIT_50_WIN@"><img
+											src="images/windows_download.png"
+											alt="Windows Client Download" /></a></td>
+								<td align="center">@FLIMFIT_50_WIN_SIZE@</td>
+								<td>@FLIMFIT_50_WIN_BASE@</td>
+								<td align="center">@FLIMFIT_50_WIN_MD5@ (<a
+										href="@FLIMFIT_50_WIN@.md5">MD5</a>)</td>
+							</tr>
+							<tr>
+								<td><a href="@FLIMFIT_50_MAC@"><img src="images/mac_download.png"
+											alt="Mac OS X Client Download" /></a></td>
+								<td align="center">@FLIMFIT_50_MAC_SIZE@</td>
+								<td>@FLIMFIT_50_MAC_BASE@</td>
+								<td align="center">@FLIMFIT_50_MAC_MD5@ (<a
+										href="@FLIMFIT_50_MAC@.md5">MD5</a>)</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<h2><a name="flimfit_44" id="flimfit_44"></a>FLIMFit downloads for OME 4.4.x</h2>
+				<div class="alt-table">
+					<table width="800" border="0" cellpadding="5">
+						<tbody>
+							<tr>
+								<th width="269">Clients</th>
+								<th width="85">Size</th>
+								<th width="271">File Name</th>
+								<th width="125">Checksum</th>
+							</tr>
+							<tr>
+								<td><a href="@FLIMFIT_44_WIN@"><img
+											src="images/windows_download.png"
+											alt="Windows Client Download" /></a></td>
+								<td align="center">@FLIMFIT_44_WIN_SIZE@</td>
+								<td>@FLIMFIT_44_WIN_BASE@</td>
+								<td align="center">@FLIMFIT_44_WIN_MD5@ (<a
+										href="@FLIMFIT_44_WIN@.md5">MD5</a>)</td>
+							</tr>
+							<tr>
+								<td><a href="@FLIMFIT_44_MAC@"><img src="images/mac_download.png"
+											alt="Mac OS X Client Download" /></a></td>
+								<td align="center">@FLIMFIT_44_MAC_SIZE@</td>
+								<td>@FLIMFIT_44_MAC_BASE@</td>
+								<td align="center">@FLIMFIT_44_MAC_MD5@ (<a
+										href="@FLIMFIT_44_MAC@.md5">MD5</a>)</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<h2><a name="legacy" id="legacy"></a>Legacy versions</h2>
+				<ul>
+					<li>
+						<p>We recommend that you always use the most recent release version of the
+							OMERO software, but if you need to use a previous version, they are all
+							available from the main <a
+								href="http://downloads.openmicroscopy.org/flimfit/?C=M;O=D"
+								>downloads folder</a></p>
+					</li>
+				</ul>
+			</div><!-- /.entry-content -->
+			<!-- </section> -->
+			<!-- <footer id="contentinfo" class="body">
+			</footer> --><!-- /#contentinfo -->
+			<!-- OME Footer - Start -->
+			<div class="visualClear" id="clear-space-before-footer"><!-- --></div>
+			<div id="portal-footer">
+				<p>
+					<acronym title="Copyright">&copy;</acronym> 2000-2013 University of Dundee &amp;
+					Open Microscopy Environment. <a
+						href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
+						>Creative Commons Attribution 3.0 Unported License</a>
+				</p>
+				<p> OME source code is available under the <a
+						href="http://www.openmicroscopy.org/site/about/licensing">GNU General public
+						license</a> or through commercial license from <a
+						href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software"
+						>Glencoe Software</a>
+				</p>
+			</div>
+			<div class="visualClear">
+				<!-- OME Footer - END -->
+			</div>
 		</div>
-		<div class="visualClear">
-		<!-- OME Footer - END -->
-	
-</div></div></body></html>
+	</body>
+</html>

--- a/images/flimfit_downloads.html
+++ b/images/flimfit_downloads.html
@@ -1,170 +1,191 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
-	<head>
-		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 
-		<link rel="stylesheet" href="images/plonematch.css" type="text/css" />
-		<style type="text/css">
-			[touch-action = "none"]{
-				-ms-touch-action:none;
-				touch-action:none;
-			}
-			[touch-action = "pan-x"]{
-				-ms-touch-action:pan-x;
-				touch-action:pan-x;
-			}
-			[touch-action = "pan-y"]{
-				-ms-touch-action:pan-y;
-				touch-action:pan-y;
-			}
-			[touch-action = "scroll"],
-			[touch-action = "pan-x pan-y"],
-			[touch-action = "pan-y pan-x"]{
-				-ms-touch-action:pan-x pan-y;
-				touch-action:pan-x pan-y;
-			}</style>
-		<title></title>
-	</head>
-	<body id="index" class="home">
-		<!-- OME Banner - START -->
-		<div id="portal-top">
-			<div id="portal-header">
-				<ul id="portal-siteactions">
-					<li>
-						<br />
-					</li>
-				</ul><a id="portal-logo" accesskey="1" href="http://downloads.openmicroscopy.org/"
-					name="portal-logo"><img src="images/logo.jpg" alt="" title="" height="73"
-						width="450" /></a>
-				<div id="portal-globalnav">
-					<br />
-				</div>
-			</div>
-			<div id="portal-personaltools-wrapper">
-				<ul id="portal-personaltools" class="visualInline">
-					<li>
-						<br />
-					</li>
-				</ul>
-			</div>
-		</div>
-		<div class="visualClear" id="clear-space-before-wrapper-table">
-			<!-- OME Banner - END -->
-			<!-- /#menu -->
-			<!-- <section id="content" class="body" style="margin-left:20px;"> -->
-			<div class="entry-content">
-				<h2>FLIMFit @VERSION@ Downloads</h2>
-				<p>
-					<strong><a href="#flimfit_50">OME 5.0</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
-							href="#flimfit_44">OME 4.4</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#legacy"
-							>Legacy</a>
-					</strong></p>
-				<ul>
+        <link rel="stylesheet" href="images/plonematch.css" type="text/css" />
+        <style type="text/css">
+            [touch-action = "none"]{
+                -ms-touch-action:none;
+                touch-action:none;
+            }
+            [touch-action = "pan-x"]{
+                -ms-touch-action:pan-x;
+                touch-action:pan-x;
+            }
+            [touch-action = "pan-y"]{
+                -ms-touch-action:pan-y;
+                touch-action:pan-y;
+            }
+            [touch-action = "scroll"],
+            [touch-action = "pan-x pan-y"],
+            [touch-action = "pan-y pan-x"]{
+                -ms-touch-action:pan-x pan-y;
+                touch-action:pan-x pan-y;
+            }</style>
+        <title></title>
+    </head>
+    <body id="index" class="home">
+        <!-- OME Banner - START -->
+        <div id="portal-top">
+            <div id="portal-header">
+                <ul id="portal-siteactions">
+                    <li>
+                        <br />
+                    </li>
+                </ul><a id="portal-logo" accesskey="1"
+                    href="http://downloads.openmicroscopy.org/"
+                    name="portal-logo"><img src="images/logo.jpg" alt=""
+                        title="" height="73" width="450" /></a>
+                <div id="portal-globalnav">
+                    <br />
+                </div>
+            </div>
+            <div id="portal-personaltools-wrapper">
+                <ul id="portal-personaltools" class="visualInline">
+                    <li>
+                        <br />
+                    </li>
+                </ul>
+            </div>
+        </div>
+        <div class="visualClear" id="clear-space-before-wrapper-table">
+            <!-- OME Banner - END -->
+            <!-- /#menu -->
+            <!-- <section id="content" class="body" style="margin-left:20px;"> -->
+            <div class="entry-content">
+                <h2>FLIMFit @VERSION@ Downloads</h2>
+                <p>
+                    <strong><a href="#flimfit_50">OME
+                            5.0</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
+                            href="#flimfit_44">OME
+                            4.4</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#legacy"
+                            >Legacy</a>
+                    </strong></p>
+                <ul>
 
-					<li>
-						<p>Full documentation is available as <a href="@DOC_URL@">web
-								documentation</a> or <a href="@DOC@">PDF documentation</a> and there
-							are user guides for the clients on our <a
-								href="http://help.openmicroscopy.org">Help website</a></p>
-					</li>
-					<li>
-						<p>To use the compiled version below, you will need to download the MATLAB
-							MCR corresponding to your system.</p>
-					</li>
-				</ul>
-				<h2><a name="flimfit_50" id="flimfit_50"></a>FLIMFit downloads for OME 5.0.x</h2>
-				<div class="alt-table">
-					<table width="800" border="0" cellpadding="5">
-						<tbody>
-							<tr>
-								<th width="269">Clients</th>
-								<th width="85">Size</th>
-								<th width="271">File Name</th>
-								<th width="125">Checksum</th>
-							</tr>
-							<tr>
-								<td><a href="@FLIMFIT_50_WIN@"><img
-											src="images/windows_download.png"
-											alt="Windows Client Download" /></a></td>
-								<td align="center">@FLIMFIT_50_WIN_SIZE@</td>
-								<td>@FLIMFIT_50_WIN_BASE@</td>
-								<td align="center">@FLIMFIT_50_WIN_MD5@ (<a
-										href="@FLIMFIT_50_WIN@.md5">MD5</a>)</td>
-							</tr>
-							<tr>
-								<td><a href="@FLIMFIT_50_MAC@"><img src="images/mac_download.png"
-											alt="Mac OS X Client Download" /></a></td>
-								<td align="center">@FLIMFIT_50_MAC_SIZE@</td>
-								<td>@FLIMFIT_50_MAC_BASE@</td>
-								<td align="center">@FLIMFIT_50_MAC_MD5@ (<a
-										href="@FLIMFIT_50_MAC@.md5">MD5</a>)</td>
-							</tr>
-						</tbody>
-					</table>
-				</div>
-				<h2><a name="flimfit_44" id="flimfit_44"></a>FLIMFit downloads for OME 4.4.x</h2>
-				<div class="alt-table">
-					<table width="800" border="0" cellpadding="5">
-						<tbody>
-							<tr>
-								<th width="269">Clients</th>
-								<th width="85">Size</th>
-								<th width="271">File Name</th>
-								<th width="125">Checksum</th>
-							</tr>
-							<tr>
-								<td><a href="@FLIMFIT_44_WIN@"><img
-											src="images/windows_download.png"
-											alt="Windows Client Download" /></a></td>
-								<td align="center">@FLIMFIT_44_WIN_SIZE@</td>
-								<td>@FLIMFIT_44_WIN_BASE@</td>
-								<td align="center">@FLIMFIT_44_WIN_MD5@ (<a
-										href="@FLIMFIT_44_WIN@.md5">MD5</a>)</td>
-							</tr>
-							<tr>
-								<td><a href="@FLIMFIT_44_MAC@"><img src="images/mac_download.png"
-											alt="Mac OS X Client Download" /></a></td>
-								<td align="center">@FLIMFIT_44_MAC_SIZE@</td>
-								<td>@FLIMFIT_44_MAC_BASE@</td>
-								<td align="center">@FLIMFIT_44_MAC_MD5@ (<a
-										href="@FLIMFIT_44_MAC@.md5">MD5</a>)</td>
-							</tr>
-						</tbody>
-					</table>
-				</div>
-				<h2><a name="legacy" id="legacy"></a>Legacy versions</h2>
-				<ul>
-					<li>
-						<p>We recommend that you always use the most recent release version of the
-							OMERO software, but if you need to use a previous version, they are all
-							available from the main <a
-								href="http://downloads.openmicroscopy.org/flimfit/?C=M;O=D"
-								>downloads folder</a></p>
-					</li>
-				</ul>
-			</div><!-- /.entry-content -->
-			<!-- </section> -->
-			<!-- <footer id="contentinfo" class="body">
+                    <li>
+                        <p>Full documentation is available as <a
+                                href="@DOC_URL@">web documentation</a> or <a
+                                href="@DOC@">PDF documentation</a> and there are
+                            user guides for the clients on our <a
+                                href="http://help.openmicroscopy.org">Help
+                                website</a></p>
+                    </li>
+                    <li>
+                        <p>To use the compiled version below, you will need to
+                            download the MATLAB MCR corresponding to your
+                            system.</p>
+                    </li>
+                </ul>
+                <h2><a name="flimfit_50" id="flimfit_50"></a>FLIMFit downloads
+                    for OME 5.0.x</h2>
+                <div class="alt-table">
+                    <table width="800" border="0" cellpadding="5">
+                        <tbody>
+                            <tr>
+                                <th width="269">Clients</th>
+                                <th width="85">Size</th>
+                                <th width="271">File Name</th>
+                                <th width="125">Checksum</th>
+                            </tr>
+                            <tr>
+                                <td><a href="@FLIMFIT_50_WIN@"><img
+                                        src="images/windows_download.png"
+                                        alt="Windows Client Download"
+                                     /></a></td>
+                                <td align="center">@FLIMFIT_50_WIN_SIZE@</td>
+                                <td>@FLIMFIT_50_WIN_BASE@</td>
+                                <td align="center">@FLIMFIT_50_WIN_MD5@ (<a
+                                        href="@FLIMFIT_50_WIN@.md5"
+                                    >MD5</a>)</td>
+                            </tr>
+                            <tr>
+                                <td><a href="@FLIMFIT_50_MAC@"><img
+                                        src="images/mac_download.png"
+                                        alt="Mac OS X Client Download"
+                                     /></a></td>
+                                <td align="center">@FLIMFIT_50_MAC_SIZE@</td>
+                                <td>@FLIMFIT_50_MAC_BASE@</td>
+                                <td align="center">@FLIMFIT_50_MAC_MD5@ (<a
+                                        href="@FLIMFIT_50_MAC@.md5"
+                                    >MD5</a>)</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <h2><a name="flimfit_44" id="flimfit_44"></a>FLIMFit downloads
+                    for OME 4.4.x</h2>
+                <div class="alt-table">
+                    <table width="800" border="0" cellpadding="5">
+                        <tbody>
+                            <tr>
+                                <th width="269">Clients</th>
+                                <th width="85">Size</th>
+                                <th width="271">File Name</th>
+                                <th width="125">Checksum</th>
+                            </tr>
+                            <tr>
+                                <td><a href="@FLIMFIT_44_WIN@"><img
+                                        src="images/windows_download.png"
+                                        alt="Windows Client Download"
+                                     /></a></td>
+                                <td align="center">@FLIMFIT_44_WIN_SIZE@</td>
+                                <td>@FLIMFIT_44_WIN_BASE@</td>
+                                <td align="center">@FLIMFIT_44_WIN_MD5@ (<a
+                                        href="@FLIMFIT_44_WIN@.md5"
+                                    >MD5</a>)</td>
+                            </tr>
+                            <tr>
+                                <td><a href="@FLIMFIT_44_MAC@"><img
+                                        src="images/mac_download.png"
+                                        alt="Mac OS X Client Download"
+                                     /></a></td>
+                                <td align="center">@FLIMFIT_44_MAC_SIZE@</td>
+                                <td>@FLIMFIT_44_MAC_BASE@</td>
+                                <td align="center">@FLIMFIT_44_MAC_MD5@ (<a
+                                        href="@FLIMFIT_44_MAC@.md5"
+                                    >MD5</a>)</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <h2><a name="legacy" id="legacy"></a>Legacy versions</h2>
+                <ul>
+                    <li>
+                        <p>We recommend that you always use the most recent
+                            release version of the OMERO software, but if you
+                            need to use a previous version, they are all
+                            available from the main <a
+                                href="http://downloads.openmicroscopy.org/flimfit/?C=M;O=D"
+                                >downloads folder</a></p>
+                    </li>
+                </ul>
+            </div><!-- /.entry-content -->
+            <!-- </section> -->
+            <!-- <footer id="contentinfo" class="body">
 			</footer> --><!-- /#contentinfo -->
-			<!-- OME Footer - Start -->
-			<div class="visualClear" id="clear-space-before-footer"><!-- --></div>
-			<div id="portal-footer">
-				<p>
-					<acronym title="Copyright">&copy;</acronym> 2000-2013 University of Dundee &amp;
-					Open Microscopy Environment. <a
-						href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
-						>Creative Commons Attribution 3.0 Unported License</a>
-				</p>
-				<p> OME source code is available under the <a
-						href="http://www.openmicroscopy.org/site/about/licensing">GNU General public
-						license</a> or through commercial license from <a
-						href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software"
-						>Glencoe Software</a>
-				</p>
-			</div>
-			<div class="visualClear">
-				<!-- OME Footer - END -->
-			</div>
-		</div>
-	</body>
+            <!-- OME Footer - Start -->
+            <div class="visualClear" id="clear-space-before-footer"
+                ><!-- --></div>
+            <div id="portal-footer">
+                <p>
+                    <acronym title="Copyright">&copy;</acronym> 2000-2013
+                    University of Dundee &amp; Open Microscopy Environment. <a
+                        href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
+                        >Creative Commons Attribution 3.0 Unported License</a>
+                </p>
+                <p> OME source code is available under the <a
+                        href="http://www.openmicroscopy.org/site/about/licensing"
+                        >GNU General public license</a> or through commercial
+                    license from <a
+                        href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software"
+                        >Glencoe Software</a>
+                </p>
+            </div>
+            <div class="visualClear">
+                <!-- OME Footer - END -->
+            </div>
+        </div>
+    </body>
 </html>

--- a/images/flimfit_downloads.html
+++ b/images/flimfit_downloads.html
@@ -51,9 +51,7 @@
         </div>
         <div class="visualClear" id="clear-space-before-wrapper-table">
             <!-- OME Banner - END -->
-            <!-- /#menu -->
-            <!-- <section id="content" class="body" style="margin-left:20px;"> -->
-            <div class="entry-content">
+            <div class="entry-content" style="margin-left:20px;">
                 <h2>FLIMFit @VERSION@ Downloads</h2>
                 <p>
                     <strong><a href="#flimfit_50">OME
@@ -162,9 +160,7 @@
                     </li>
                 </ul>
             </div><!-- /.entry-content -->
-            <!-- </section> -->
-            <!-- <footer id="contentinfo" class="body">
-			</footer> --><!-- /#contentinfo -->
+
             <!-- OME Footer - Start -->
             <div class="visualClear" id="clear-space-before-footer"
                 ><!-- --></div>

--- a/mtools_downloads.html
+++ b/mtools_downloads.html
@@ -85,7 +85,7 @@
                 </ul>
                 <h2><a name="mtools" id="mtools"></a>OMERO.mtools downloads</h2>
                 <div class="alt-table">
-                    <table width="800" border="0" cellpadding="5">
+                    <table width="800" border="0" cellpadding="5" summary="OMERO.mtools downloads">
                         <tbody>
                             <tr>
                                 <th width="269">Clients</th>
@@ -118,7 +118,7 @@
                 </div>
                 <h2><a name="mcr" id="mcr"></a>MCR downloads</h2>
                 <div class="alt-table">
-                    <table width="269" border="0" cellpadding="5">
+                    <table width="269" border="0" cellpadding="5" summary="MCR downloads">
                         <tbody>
                             <tr>
                                 <th width="269">MCR</th>

--- a/mtools_downloads.html
+++ b/mtools_downloads.html
@@ -1,165 +1,179 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
-	<head>
-		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-		<link rel="stylesheet" href="images/plonematch.css" type="text/css" />
-		<style type="text/css">
-			[touch-action = "none"]{
-				-ms-touch-action:none;
-				touch-action:none;
-			}
-			[touch-action = "pan-x"]{
-				-ms-touch-action:pan-x;
-				touch-action:pan-x;
-			}
-			[touch-action = "pan-y"]{
-				-ms-touch-action:pan-y;
-				touch-action:pan-y;
-			}
-			[touch-action = "scroll"],
-			[touch-action = "pan-x pan-y"],
-			[touch-action = "pan-y pan-x"]{
-				-ms-touch-action:pan-x pan-y;
-				touch-action:pan-x pan-y;
-			}</style>
-		<title></title>
-	</head>
-	<body id="index" class="home">
-		<!-- OME Banner - START -->
-		<div id="portal-top">
-			<div id="portal-header">
-				<ul id="portal-siteactions">
-					<li>
-						<br />
-					</li>
-				</ul><a id="portal-logo" accesskey="1" href="http://downloads.openmicroscopy.org/"
-					name="portal-logo"><img src="images/logo.jpg" alt="" title="" height="73"
-						width="450" /></a>
-				<div id="portal-globalnav">
-					<br />
-				</div>
-			</div>
-			<div id="portal-personaltools-wrapper">
-				<ul id="portal-personaltools" class="visualInline">
-					<li>
-						<br />
-					</li>
-				</ul>
-			</div>
-		</div>
-		<div class="visualClear" id="clear-space-before-wrapper-table">
-			<!-- OME Banner - END -->
-			<!-- /#menu -->
-			<!-- <section id="content" class="body" style="margin-left:20px;"> -->
-			<div class="entry-content">
-				<h2>OMERO.mtools @VERSION@ Downloads</h2>
-				<p>
-					<strong><a href="#mtools">OMERO.mtools</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
-							href="#mcr">MCR</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#previous">Previous
-							versions</a>
-					</strong></p>
-				<ul>
-					<li>
-						<p>OMERO.mtools is a suite of tools written in MATLAB for various analyses
-							of images stored in an OMERO server. Please see the <a
-								href="https://www.openmicroscopy.org/site/products/partner/omero.mtools"
-								>Product page</a> for information.</p></li>
-					<li><p>Choose the version of OMERO.mtools for your platform (Windows/Mac)
-							below.</p></li>
-					<li><p>Ensure you have the correct MCR (MATLAB Compiler Runtime) installed on
-							your system (currently 2013b, v8.2). If you do not, or are in any doubt,
-							please also download the MCR for your platform below.</p></li>
-					<li><p>The MCR must be installed before running OMERO.mtools.</p></li>
-					<li><p>Once downloaded simply unzip and run. Running from a network drive is not
-							recommended.</p></li>
-					<li><p>Source code is available on <a
-								href="https://github.com/mporter-gre/mtools">GitHub</a>.</p>
-					</li>
-				</ul>
-				<h2><a name="mtools" id="mtools"></a>OMERO.mtools downloads</h2>
-				<div class="alt-table">
-					<table width="800" border="0" cellpadding="5">
-						<tbody>
-							<tr>
-								<th width="269">Clients</th>
-								<th width="85">Size</th>
-								<th width="271">File Name</th>
-								<th width="125">Checksum</th>
-							</tr>
-							<tr>
-								<td><a href="@MTOOLS_WIN@"><img src="images/omero_mtools_win.png"
-											alt="Windows Client Download" /></a></td>
-								<td align="center">@MTOOLS_WIN_SIZE@</td>
-								<td>@MTOOLS_WIN_BASE@</td>
-								<td align="center">@MTOOLS_WIN_MD5@ (<a href="@MTOOLS_WIN@.md5"
-										>MD5</a>)</td>
-							</tr>
-							<tr>
-								<td><a href="@MTOOLS_MAC@"><img src="images/omero_mtools_mac.png"
-											alt="Mac OS X Client Download" /></a></td>
-								<td align="center">@MTOOLS_MAC_SIZE@</td>
-								<td>@MTOOLS_MAC_BASE@</td>
-								<td align="center">@MTOOLS_MAC_MD5@ (<a href="@MTOOLS_MAC@.md5"
-										>MD5</a>)</td>
-							</tr>
-						</tbody>
-					</table>
-				</div>
-				<h2><a name="mcr" id="mcr"></a>MCR downloads</h2>
-				<div class="alt-table">
-					<table width="269" border="0" cellpadding="5">
-						<tbody>
-							<tr>
-								<th width="269">MCR</th>
-							</tr>
-							<tr>
-								<td><a
-										href="http://www.mathworks.com/supportfiles/downloads/R2013b/deployment_files/R2013b/installers/win64/MCR_R2013b_win64_installer.exe"
-											><img src="images/mcr_windows.png"
-											alt="Windows MCR Download" /></a></td>
-							</tr>
-							<tr>
-								<td><a
-										href="http://www.mathworks.com/supportfiles/downloads/R2013b/deployment_files/R2013b/installers/maci64/MCR_R2013b_maci64_installer.zip"
-											><img src="images/mcr_mac.png" alt="Mac MCR Download"
-										 /></a></td>
-							</tr>
-						</tbody>
-					</table>
-				</div>
-				<h2><a name="previous" id="previous"></a>Previous versions</h2>
-				<ul>
-					<li>
-						<p>We recommend that you always use the most recent release version of
-							OMERO.mtools, but if you need to use a previous version, they are all
-							available from the main <a
-								href="http://downloads.openmicroscopy.org/mtools/?C=M;O=D">downloads
-								folder</a></p>
-					</li>
-				</ul>
-			</div><!-- /.entry-content -->
-			<!-- </section> -->
-			<!-- <footer id="contentinfo" class="body">
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+        <link rel="stylesheet" href="images/plonematch.css" type="text/css" />
+        <style type="text/css">
+            [touch-action = "none"]{
+                -ms-touch-action:none;
+                touch-action:none;
+            }
+            [touch-action = "pan-x"]{
+                -ms-touch-action:pan-x;
+                touch-action:pan-x;
+            }
+            [touch-action = "pan-y"]{
+                -ms-touch-action:pan-y;
+                touch-action:pan-y;
+            }
+            [touch-action = "scroll"],
+            [touch-action = "pan-x pan-y"],
+            [touch-action = "pan-y pan-x"]{
+                -ms-touch-action:pan-x pan-y;
+                touch-action:pan-x pan-y;
+            }</style>
+        <title></title>
+    </head>
+    <body id="index" class="home">
+        <!-- OME Banner - START -->
+        <div id="portal-top">
+            <div id="portal-header">
+                <ul id="portal-siteactions">
+                    <li>
+                        <br />
+                    </li>
+                </ul><a id="portal-logo" accesskey="1"
+                    href="http://downloads.openmicroscopy.org/"
+                    name="portal-logo"><img src="images/logo.jpg" alt=""
+                        title="" height="73" width="450" /></a>
+                <div id="portal-globalnav">
+                    <br />
+                </div>
+            </div>
+            <div id="portal-personaltools-wrapper">
+                <ul id="portal-personaltools" class="visualInline">
+                    <li>
+                        <br />
+                    </li>
+                </ul>
+            </div>
+        </div>
+        <div class="visualClear" id="clear-space-before-wrapper-table">
+            <!-- OME Banner - END -->
+            <!-- /#menu -->
+            <!-- <section id="content" class="body" style="margin-left:20px;"> -->
+            <div class="entry-content">
+                <h2>OMERO.mtools @VERSION@ Downloads</h2>
+                <p>
+                    <strong><a href="#mtools"
+                            >OMERO.mtools</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
+                            href="#mcr">MCR</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
+                            href="#previous">Previous versions</a>
+                    </strong></p>
+                <ul>
+                    <li>
+                        <p>OMERO.mtools is a suite of tools written in MATLAB
+                            for various analyses of images stored in an OMERO
+                            server. Please see the <a
+                                href="https://www.openmicroscopy.org/site/products/partner/omero.mtools"
+                                >Product page</a> for information.</p></li>
+                    <li><p>Choose the version of OMERO.mtools for your platform
+                            (Windows/Mac) below.</p></li>
+                    <li><p>Ensure you have the correct MCR (MATLAB Compiler
+                            Runtime) installed on your system (currently 2013b,
+                            v8.2). If you do not, or are in any doubt, please
+                            also download the MCR for your platform
+                        below.</p></li>
+                    <li><p>The MCR must be installed before running
+                            OMERO.mtools.</p></li>
+                    <li><p>Once downloaded simply unzip and run. Running from a
+                            network drive is not recommended.</p></li>
+                    <li><p>Source code is available on <a
+                                href="https://github.com/mporter-gre/mtools"
+                                >GitHub</a>.</p>
+                    </li>
+                </ul>
+                <h2><a name="mtools" id="mtools"></a>OMERO.mtools downloads</h2>
+                <div class="alt-table">
+                    <table width="800" border="0" cellpadding="5">
+                        <tbody>
+                            <tr>
+                                <th width="269">Clients</th>
+                                <th width="85">Size</th>
+                                <th width="271">File Name</th>
+                                <th width="125">Checksum</th>
+                            </tr>
+                            <tr>
+                                <td><a href="@MTOOLS_WIN@"><img
+                                        src="images/omero_mtools_win.png"
+                                        alt="Windows Client Download"
+                                     /></a></td>
+                                <td align="center">@MTOOLS_WIN_SIZE@</td>
+                                <td>@MTOOLS_WIN_BASE@</td>
+                                <td align="center">@MTOOLS_WIN_MD5@ (<a
+                                        href="@MTOOLS_WIN@.md5">MD5</a>)</td>
+                            </tr>
+                            <tr>
+                                <td><a href="@MTOOLS_MAC@"><img
+                                        src="images/omero_mtools_mac.png"
+                                        alt="Mac OS X Client Download"
+                                     /></a></td>
+                                <td align="center">@MTOOLS_MAC_SIZE@</td>
+                                <td>@MTOOLS_MAC_BASE@</td>
+                                <td align="center">@MTOOLS_MAC_MD5@ (<a
+                                        href="@MTOOLS_MAC@.md5">MD5</a>)</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <h2><a name="mcr" id="mcr"></a>MCR downloads</h2>
+                <div class="alt-table">
+                    <table width="269" border="0" cellpadding="5">
+                        <tbody>
+                            <tr>
+                                <th width="269">MCR</th>
+                            </tr>
+                            <tr>
+                                <td><a
+                                        href="http://www.mathworks.com/supportfiles/downloads/R2013b/deployment_files/R2013b/installers/win64/MCR_R2013b_win64_installer.exe"
+                                        ><img src="images/mcr_windows.png"
+                                        alt="Windows MCR Download" /></a></td>
+                            </tr>
+                            <tr>
+                                <td><a
+                                        href="http://www.mathworks.com/supportfiles/downloads/R2013b/deployment_files/R2013b/installers/maci64/MCR_R2013b_maci64_installer.zip"
+                                        ><img src="images/mcr_mac.png"
+                                        alt="Mac MCR Download" /></a></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <h2><a name="previous" id="previous"></a>Previous versions</h2>
+                <ul>
+                    <li>
+                        <p>We recommend that you always use the most recent
+                            release version of OMERO.mtools, but if you need to
+                            use a previous version, they are all available from
+                            the main <a
+                                href="http://downloads.openmicroscopy.org/mtools/?C=M;O=D"
+                                >downloads folder</a></p>
+                    </li>
+                </ul>
+            </div><!-- /.entry-content -->
+            <!-- </section> -->
+            <!-- <footer id="contentinfo" class="body">
 			</footer> --><!-- /#contentinfo -->
-			<!-- OME Footer - Start -->
-			<div class="visualClear" id="clear-space-before-footer"><!-- --></div>
-			<div id="portal-footer">
-				<p>
-					<acronym title="Copyright">&copy;</acronym> 2000-2014 University of Dundee &amp;
-					Open Microscopy Environment. <a
-						href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
-						>Creative Commons Attribution 3.0 Unported License</a>
-				</p>
-				<p> OME source code is available under the <a
-						href="http://www.openmicroscopy.org/site/about/licensing">GNU General public
-						license</a> or through commercial license from <a
-						href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software"
-						>Glencoe Software</a>
-				</p>
-			</div>
-			<div class="visualClear">
-				<!-- OME Footer - END -->
-			</div>
-		</div>
-	</body>
+            <!-- OME Footer - Start -->
+            <div class="visualClear" id="clear-space-before-footer"
+                ><!-- --></div>
+            <div id="portal-footer">
+                <p>
+                    <acronym title="Copyright">&copy;</acronym> 2000-2014
+                    University of Dundee &amp; Open Microscopy Environment. <a
+                        href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
+                        >Creative Commons Attribution 3.0 Unported License</a>
+                </p>
+                <p> OME source code is available under the <a
+                        href="http://www.openmicroscopy.org/site/about/licensing"
+                        >GNU General public license</a> or through commercial
+                    license from <a
+                        href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software"
+                        >Glencoe Software</a>
+                </p>
+            </div>
+            <div class="visualClear">
+                <!-- OME Footer - END -->
+            </div>
+        </div>
+    </body>
 </html>

--- a/mtools_downloads.html
+++ b/mtools_downloads.html
@@ -1,128 +1,165 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-
-        <link rel="stylesheet" href="images/plonematch.css" type="text/css">
-        <meta charset="utf-8">
-
-
-      <meta name="tags" contents="mtools">
-
-    <style type="text/css"></style><style>[touch-action="none"]{ -ms-touch-action: none; touch-action: none; }[touch-action="pan-x"]{ -ms-touch-action: pan-x; touch-action: pan-x; }[touch-action="pan-y"]{ -ms-touch-action: pan-y; touch-action: pan-y; }[touch-action="scroll"],[touch-action="pan-x pan-y"],[touch-action="pan-y pan-x"]{ -ms-touch-action: pan-x pan-y; touch-action: pan-x pan-y; }</style></head>
-    <body id="index" class="home">
-
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+		<link rel="stylesheet" href="images/plonematch.css" type="text/css" />
+		<style type="text/css">
+			[touch-action = "none"]{
+				-ms-touch-action:none;
+				touch-action:none;
+			}
+			[touch-action = "pan-x"]{
+				-ms-touch-action:pan-x;
+				touch-action:pan-x;
+			}
+			[touch-action = "pan-y"]{
+				-ms-touch-action:pan-y;
+				touch-action:pan-y;
+			}
+			[touch-action = "scroll"],
+			[touch-action = "pan-x pan-y"],
+			[touch-action = "pan-y pan-x"]{
+				-ms-touch-action:pan-x pan-y;
+				touch-action:pan-x pan-y;
+			}</style>
+		<title></title>
+	</head>
+	<body id="index" class="home">
 		<!-- OME Banner - START -->
 		<div id="portal-top">
 			<div id="portal-header">
 				<ul id="portal-siteactions">
 					<li>
-						<br>
+						<br />
 					</li>
-				</ul><a id="portal-logo" accesskey="1" href="http://downloads.openmicroscopy.org/" name="portal-logo"><img src="images/logo.jpg" alt="" title="" height="73" width="450"></a>
-			  <div id="portal-globalnav">
-					<br>
+				</ul><a id="portal-logo" accesskey="1" href="http://downloads.openmicroscopy.org/"
+					name="portal-logo"><img src="images/logo.jpg" alt="" title="" height="73"
+						width="450" /></a>
+				<div id="portal-globalnav">
+					<br />
 				</div>
 			</div>
 			<div id="portal-personaltools-wrapper">
 				<ul id="portal-personaltools" class="visualInline">
 					<li>
-						<br>
+						<br />
 					</li>
 				</ul>
 			</div>
 		</div>
 		<div class="visualClear" id="clear-space-before-wrapper-table">
-		<!-- OME Banner - END -->
-
-                                  <!-- /#menu -->
-<section id="content" class="body" style="margin-left:20px;">
-
-<div class="entry-content">
-
-<h2>OMERO.mtools @VERSION@ Downloads</h2>
-
-<p>
-  <strong><a href="#mtools">OMERO.mtools</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#mcr">MCR</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#previous">Previous versions</a> </strong></p>
-
-<ul>
-<li>
-<p>OMERO.mtools is a suite of tools written in MATLAB for various analyses of images stored in an OMERO server. Please see the <a href="https://www.openmicroscopy.org/site/products/partner/omero.mtools">Product page</a> for information.</p></li>
-<li><p>Choose the version of OMERO.mtools for your platform (Windows/Mac) below.</p></li>
-<li><p>Ensure you have the correct MCR (MATLAB Compiler Runtime) installed on your system (currently 2013b, v8.2). If you do not, or are in any doubt, please also download the MCR for your platform below.</p></li>
-<li><p>The MCR must be installed before running OMERO.mtools.</p></li>
-<li><p>Once downloaded simply unzip and run. Running from a network drive is not recommended.</p></li>
-<li><p>Source code is available on <a href="https://github.com/mporter-gre/mtools">GitHub</a>.</p>
-</li>
-</ul>
-
-<h2><a name="mtools" id="mtools"></a>OMERO.mtools downloads</h2>
-<div class="alt-table">
-  <table width="800" border="0" cellpadding="5">
-    <tbody>
-      <tr>
-        <th width="269">Clients</th>
-        <th width="85">Size</th>
-        <th width="271">File Name</th>
-        <th width="125">Checksum</th>
-        </tr>
-      <tr>
-        <td><a href="@MTOOLS_WIN@"><img src="images/omero_mtools_win.png" alt="Windows Client Download" /></a></td>
-        <td align="center">@MTOOLS_WIN_SIZE@</td>
-        <td>@MTOOLS_WIN_BASE@</td>
-        <td align="center">@MTOOLS_WIN_MD5@ (<a href="@MTOOLS_WIN@.md5">MD5</a>)</td>
-      </tr>
-      <tr>
-        <td><a href="@MTOOLS_MAC@"><img src="images/omero_mtools_mac.png" alt="Mac OS X Client Download" /></a></td>
-        <td align="center">@MTOOLS_MAC_SIZE@</td>
-        <td>@MTOOLS_MAC_BASE@</td>
-        <td align="center">@MTOOLS_MAC_MD5@ (<a href="@MTOOLS_MAC@.md5">MD5</a>)</td>
-        </tr>
-    </tbody>
-  </table>
-</div>
-
-<h2><a name="mcr" id="mcr"></a>MCR downloads</h2>
-<div class="alt-table">
-  <table width="269" border="0" cellpadding="5">
-    <tbody>
-      <tr>
-        <th width="269">MCR</th>
-        </tr>
-      <tr>
-        <td><a href="http://www.mathworks.com/supportfiles/downloads/R2013b/deployment_files/R2013b/installers/win64/MCR_R2013b_win64_installer.exe"><img src="images/mcr_windows.png" alt="Windows MCR Download" /></a></td>
-      </tr>
-      <tr>
-        <td><a href="http://www.mathworks.com/supportfiles/downloads/R2013b/deployment_files/R2013b/installers/maci64/MCR_R2013b_maci64_installer.zip"><img src="images/mcr_mac.png" alt="Mac MCR Download" /></a></td>
-        </tr>
-    </tbody>
-  </table>
-</div>
-
-<h2><a name="previous" id="previous"></a>Previous versions</h2>
-
-<ul>
-  <li>
-<p>We recommend that you always use the most recent release version of OMERO.mtools, but if you need to use a previous version,  they are all available from the main <a href="http://downloads.openmicroscopy.org/mtools/?C=M;O=D">downloads folder</a></p>
-  </li>
-</ul>
-
-  </div><!-- /.entry-content -->
-</section>
-        <footer id="contentinfo" class="body">
-        </footer><!-- /#contentinfo -->
-
-		<!-- OME Footer - Start -->
-		<div class="visualClear" id="clear-space-before-footer"><!-- --></div>
-		<div id="portal-footer">
-			<p>
-				<acronym title="Copyright">&copy;</acronym>
-				2000-2014
-				University of Dundee &amp; Open Microscopy Environment. <a href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing">Creative Commons Attribution 3.0 Unported License</a>
-			</p>
-			<p>
-				OME source code is available under the <a href="http://www.openmicroscopy.org/site/about/licensing">GNU General public license</a> or through commercial license from <a href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software">Glencoe Software</a>
-			</p>
+			<!-- OME Banner - END -->
+			<!-- /#menu -->
+			<!-- <section id="content" class="body" style="margin-left:20px;"> -->
+			<div class="entry-content">
+				<h2>OMERO.mtools @VERSION@ Downloads</h2>
+				<p>
+					<strong><a href="#mtools">OMERO.mtools</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
+							href="#mcr">MCR</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#previous">Previous
+							versions</a>
+					</strong></p>
+				<ul>
+					<li>
+						<p>OMERO.mtools is a suite of tools written in MATLAB for various analyses
+							of images stored in an OMERO server. Please see the <a
+								href="https://www.openmicroscopy.org/site/products/partner/omero.mtools"
+								>Product page</a> for information.</p></li>
+					<li><p>Choose the version of OMERO.mtools for your platform (Windows/Mac)
+							below.</p></li>
+					<li><p>Ensure you have the correct MCR (MATLAB Compiler Runtime) installed on
+							your system (currently 2013b, v8.2). If you do not, or are in any doubt,
+							please also download the MCR for your platform below.</p></li>
+					<li><p>The MCR must be installed before running OMERO.mtools.</p></li>
+					<li><p>Once downloaded simply unzip and run. Running from a network drive is not
+							recommended.</p></li>
+					<li><p>Source code is available on <a
+								href="https://github.com/mporter-gre/mtools">GitHub</a>.</p>
+					</li>
+				</ul>
+				<h2><a name="mtools" id="mtools"></a>OMERO.mtools downloads</h2>
+				<div class="alt-table">
+					<table width="800" border="0" cellpadding="5">
+						<tbody>
+							<tr>
+								<th width="269">Clients</th>
+								<th width="85">Size</th>
+								<th width="271">File Name</th>
+								<th width="125">Checksum</th>
+							</tr>
+							<tr>
+								<td><a href="@MTOOLS_WIN@"><img src="images/omero_mtools_win.png"
+											alt="Windows Client Download" /></a></td>
+								<td align="center">@MTOOLS_WIN_SIZE@</td>
+								<td>@MTOOLS_WIN_BASE@</td>
+								<td align="center">@MTOOLS_WIN_MD5@ (<a href="@MTOOLS_WIN@.md5"
+										>MD5</a>)</td>
+							</tr>
+							<tr>
+								<td><a href="@MTOOLS_MAC@"><img src="images/omero_mtools_mac.png"
+											alt="Mac OS X Client Download" /></a></td>
+								<td align="center">@MTOOLS_MAC_SIZE@</td>
+								<td>@MTOOLS_MAC_BASE@</td>
+								<td align="center">@MTOOLS_MAC_MD5@ (<a href="@MTOOLS_MAC@.md5"
+										>MD5</a>)</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<h2><a name="mcr" id="mcr"></a>MCR downloads</h2>
+				<div class="alt-table">
+					<table width="269" border="0" cellpadding="5">
+						<tbody>
+							<tr>
+								<th width="269">MCR</th>
+							</tr>
+							<tr>
+								<td><a
+										href="http://www.mathworks.com/supportfiles/downloads/R2013b/deployment_files/R2013b/installers/win64/MCR_R2013b_win64_installer.exe"
+											><img src="images/mcr_windows.png"
+											alt="Windows MCR Download" /></a></td>
+							</tr>
+							<tr>
+								<td><a
+										href="http://www.mathworks.com/supportfiles/downloads/R2013b/deployment_files/R2013b/installers/maci64/MCR_R2013b_maci64_installer.zip"
+											><img src="images/mcr_mac.png" alt="Mac MCR Download"
+										 /></a></td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<h2><a name="previous" id="previous"></a>Previous versions</h2>
+				<ul>
+					<li>
+						<p>We recommend that you always use the most recent release version of
+							OMERO.mtools, but if you need to use a previous version, they are all
+							available from the main <a
+								href="http://downloads.openmicroscopy.org/mtools/?C=M;O=D">downloads
+								folder</a></p>
+					</li>
+				</ul>
+			</div><!-- /.entry-content -->
+			<!-- </section> -->
+			<!-- <footer id="contentinfo" class="body">
+			</footer> --><!-- /#contentinfo -->
+			<!-- OME Footer - Start -->
+			<div class="visualClear" id="clear-space-before-footer"><!-- --></div>
+			<div id="portal-footer">
+				<p>
+					<acronym title="Copyright">&copy;</acronym> 2000-2014 University of Dundee &amp;
+					Open Microscopy Environment. <a
+						href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
+						>Creative Commons Attribution 3.0 Unported License</a>
+				</p>
+				<p> OME source code is available under the <a
+						href="http://www.openmicroscopy.org/site/about/licensing">GNU General public
+						license</a> or through commercial license from <a
+						href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software"
+						>Glencoe Software</a>
+				</p>
+			</div>
+			<div class="visualClear">
+				<!-- OME Footer - END -->
+			</div>
 		</div>
-		<div class="visualClear">
-		<!-- OME Footer - END -->
-
-</div></div></body></html>
+	</body>
+</html>

--- a/mtools_downloads.html
+++ b/mtools_downloads.html
@@ -50,9 +50,7 @@
         </div>
         <div class="visualClear" id="clear-space-before-wrapper-table">
             <!-- OME Banner - END -->
-            <!-- /#menu -->
-            <!-- <section id="content" class="body" style="margin-left:20px;"> -->
-            <div class="entry-content">
+        	<div class="entry-content" style="margin-left:20px;">
                 <h2>OMERO.mtools @VERSION@ Downloads</h2>
                 <p>
                     <strong><a href="#mtools"
@@ -150,9 +148,6 @@
                     </li>
                 </ul>
             </div><!-- /.entry-content -->
-            <!-- </section> -->
-            <!-- <footer id="contentinfo" class="body">
-			</footer> --><!-- /#contentinfo -->
             <!-- OME Footer - Start -->
             <div class="visualClear" id="clear-space-before-footer"
                 ><!-- --></div>

--- a/ome_theme/templates/base.html
+++ b/ome_theme/templates/base.html
@@ -6,7 +6,6 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <link rel="stylesheet" href="/sitestyling/plonematch.css" type="text/css" />
-        <meta charset="utf-8" />
         {% block head %}
         <title>{% block title %}{{ SITENAME }}{% endblock title %}</title>
         {% if FEED_ALL_ATOM %}

--- a/omero_downloads.html
+++ b/omero_downloads.html
@@ -106,7 +106,7 @@
                 <h2><a name="clients" id="clients"></a>OMERO client
                     downloads</h2>
                 <div class="alt-table">
-                    <table width="800" border="0" cellpadding="5">
+                    <table width="800" border="0" cellpadding="5" summary="OMERO client downloads">
                         <tbody>
                             <tr>
                                 <th width="269">Clients</th>
@@ -169,7 +169,7 @@
                 <h2><a name="plugins" id="plugins"></a>OMERO plugin
                     downloads</h2>
                 <div class="alt-table">
-                    <table width="800" border="0" cellpadding="5">
+                    <table width="800" border="0" cellpadding="5" summary="OMERO plugin downloads">
                         <tbody>
                             <tr>
                                 <th width="269">Plugins</th>
@@ -235,7 +235,7 @@
                 <h2><a name="servers" id="servers"></a>OMERO server @VERSION@
                     downloads</h2>
                 <div class="alt-table">
-                    <table width="800" border="0" cellpadding="5">
+                    <table width="800" border="0" cellpadding="5" summary="OMERO server downloads">
                         <tbody>
                             <tr>
                                 <th width="269">Servers</th>
@@ -308,7 +308,7 @@
                 <h2><a name="va" id="va"></a>OMERO Virtual Appliance
                     download</h2>
                 <div class="alt-table">
-                    <table width="800" border="0" cellpadding="5">
+                    <table width="800" border="0" cellpadding="5" summary="OMERO Virtual Appliance downloads">
                         <tbody>
                             <tr>
                                 <th width="269">Virtual Appliance</th>
@@ -342,7 +342,7 @@
                 </ul>
                 <h2><a name="api" id="api"></a>OMERO API documentation</h2>
                 <div class="alt-table">
-                    <table width="800" border="0" cellpadding="5">
+                    <table width="800" border="0" cellpadding="5" summary="OMERO API documentation">
                         <tbody>
                             <tr>
                                 <th width="269">API Documentation</th>
@@ -376,7 +376,7 @@
                 </ul>
                 <h2><a name="code" id="code"></a>Checking out the code</h2>
                 <div class="alt-table">
-                    <table width="800" border="0" cellpadding="5">
+                    <table width="800" border="0" cellpadding="5" summary="OMERO Code">
                         <tbody>
                             <tr>
                                 <th width="269">Source Code</th>
@@ -397,7 +397,7 @@
                     </table>
                 </div>
                 <div class="alt-table">
-                    <table width="278" border="0" cellpadding="5">
+                    <table width="278" border="0" cellpadding="5" summary="OMERO Code Links">
                         <tbody>
                             <tr>
                                 <th width="264">Source Code Links</th>

--- a/omero_downloads.html
+++ b/omero_downloads.html
@@ -53,9 +53,7 @@
         </div>
         <div class="visualClear" id="clear-space-before-wrapper-table">
             <!-- OME Banner - END -->
-            <!-- /#menu -->
-            <!-- <section id="content" class="body" style="margin-left:20px;"> -->
-            <div class="entry-content">
+            <div class="entry-content" style="margin-left:20px;">
                 <h2>OMERO @VERSION@ Downloads</h2>
                 <p>
                     <strong><a href="#clients"
@@ -452,9 +450,7 @@
                     </li>
                 </ul>
             </div><!-- /.entry-content -->
-            <!-- </section>  -->
-            <!-- <footer id="contentinfo" class="body">
-			</footer> --><!-- /#contentinfo -->
+
             <!-- OME Footer - Start -->
             <div class="visualClear" id="clear-space-before-footer"
                 ><!-- --></div>

--- a/omero_downloads.html
+++ b/omero_downloads.html
@@ -1,425 +1,481 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
-	<head>
-		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 
-		<link rel="stylesheet" href="images/plonematch.css" type="text/css" />
+        <link rel="stylesheet" href="images/plonematch.css" type="text/css" />
 
-		<style type="text/css">
-			[touch-action = "none"]{
-				-ms-touch-action:none;
-				touch-action:none;
-			}
-			[touch-action = "pan-x"]{
-				-ms-touch-action:pan-x;
-				touch-action:pan-x;
-			}
-			[touch-action = "pan-y"]{
-				-ms-touch-action:pan-y;
-				touch-action:pan-y;
-			}
-			[touch-action = "scroll"],
-			[touch-action = "pan-x pan-y"],
-			[touch-action = "pan-y pan-x"]{
-				-ms-touch-action:pan-x pan-y;
-				touch-action:pan-x pan-y;
-			}</style>
-		<title></title>
-	</head>
+        <style type="text/css">
+            [touch-action = "none"]{
+                -ms-touch-action:none;
+                touch-action:none;
+            }
+            [touch-action = "pan-x"]{
+                -ms-touch-action:pan-x;
+                touch-action:pan-x;
+            }
+            [touch-action = "pan-y"]{
+                -ms-touch-action:pan-y;
+                touch-action:pan-y;
+            }
+            [touch-action = "scroll"],
+            [touch-action = "pan-x pan-y"],
+            [touch-action = "pan-y pan-x"]{
+                -ms-touch-action:pan-x pan-y;
+                touch-action:pan-x pan-y;
+            }</style>
+        <title></title>
+    </head>
 
-	<body id="index" class="home">
-		<!-- OME Banner - START -->
-		<div id="portal-top">
-			<div id="portal-header">
-				<ul id="portal-siteactions">
-					<li>
-						<br />
-					</li>
-				</ul><a id="portal-logo" accesskey="1" href="http://downloads.openmicroscopy.org/"
-					name="portal-logo"><img src="images/logo.jpg" alt="" title="" height="73"
-						width="450" /></a>
-				<div id="portal-globalnav">
-					<br />
-				</div>
-			</div>
-			<div id="portal-personaltools-wrapper">
-				<ul id="portal-personaltools" class="visualInline">
-					<li>
-						<br />
-					</li>
-				</ul>
-			</div>
-		</div>
-		<div class="visualClear" id="clear-space-before-wrapper-table">
-			<!-- OME Banner - END -->
-			<!-- /#menu -->
-			<!-- <section id="content" class="body" style="margin-left:20px;"> -->
-			<div class="entry-content">
-				<h2>OMERO @VERSION@ Downloads</h2>
-				<p>
-					<strong><a href="#clients">Clients</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
-							href="#plugins">Plugins</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
-							href="#additional">Additional</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
-							href="#servers">Servers</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#va"
-							>Virtual Appliance</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#api"
-							>API</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#code"
-							>Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#components"
-							>Components</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#previous">Previous
-							versions</a>
-					</strong></p>
-				<ul>
-					<li>
-						<p>Information on this release of OMERO is in the <a
-								href="@ANNOUCEMENT_URL@">release announcement</a></p>
-					</li>
+    <body id="index" class="home">
+        <!-- OME Banner - START -->
+        <div id="portal-top">
+            <div id="portal-header">
+                <ul id="portal-siteactions">
+                    <li>
+                        <br />
+                    </li>
+                </ul><a id="portal-logo" accesskey="1"
+                    href="http://downloads.openmicroscopy.org/"
+                    name="portal-logo"><img src="images/logo.jpg" alt=""
+                        title="" height="73" width="450" /></a>
+                <div id="portal-globalnav">
+                    <br />
+                </div>
+            </div>
+            <div id="portal-personaltools-wrapper">
+                <ul id="portal-personaltools" class="visualInline">
+                    <li>
+                        <br />
+                    </li>
+                </ul>
+            </div>
+        </div>
+        <div class="visualClear" id="clear-space-before-wrapper-table">
+            <!-- OME Banner - END -->
+            <!-- /#menu -->
+            <!-- <section id="content" class="body" style="margin-left:20px;"> -->
+            <div class="entry-content">
+                <h2>OMERO @VERSION@ Downloads</h2>
+                <p>
+                    <strong><a href="#clients"
+                            >Clients</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
+                            href="#plugins"
+                            >Plugins</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
+                            href="#additional"
+                            >Additional</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
+                            href="#servers"
+                            >Servers</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#va"
+                            >Virtual Appliance</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
+                            href="#api">API</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
+                            href="#code">Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
+                            href="#components"
+                            >Components</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
+                            href="#previous">Previous versions</a>
+                    </strong></p>
+                <ul>
+                    <li>
+                        <p>Information on this release of OMERO is in the <a
+                                href="@ANNOUCEMENT_URL@">release
+                                announcement</a></p>
+                    </li>
 
-					<li>
-						<p>Full documentation is available as <a href="@DOC_URL@">web
-								documentation</a> or <a href="@DOC@">PDF documentation</a> and there
-							are user guides for the clients on our <a
-								href="http://help.openmicroscopy.org">Help website</a></p>
-					</li>
-					<li>
-						<p>A standard OMERO user just needs to download the client package with the
-							same major version as their institutional server e.g. 5.0 clients with
-							the 5.0 server</p>
-					</li>
-					<li>
-						<p>If you do not have an institutional server, you can apply for an <a
-								href="http://qa.openmicroscopy.org.uk/registry/demo_account/"
-								>account on our Demo server</a> or download the <a href="#va"
-								>Virtual Appliance</a> to install your own version locally.</p>
-					</li>
-				</ul>
-				<h2><a name="clients" id="clients"></a>OMERO client downloads</h2>
-				<div class="alt-table">
-					<table width="800" border="0" cellpadding="5">
-						<tbody>
-							<tr>
-								<th width="269">Clients</th>
-								<th width="85">Size</th>
-								<th width="271">File Name</th>
-								<th width="125">Checksum</th>
-							</tr>
-							<tr>
-								<td><a href="@WIN_CLIENTS@"><img src="images/windows_download.png"
-											alt="Windows Client Download" /></a></td>
-								<td align="center">@WIN_CLIENTS_SIZE@</td>
-								<td>@WIN_CLIENTS_BASE@</td>
-								<td align="center">@WIN_CLIENTS_MD5@ (<a href="@WIN_CLIENTS@.md5"
-										>MD5</a>)</td>
-							</tr>
-							<tr>
-								<td><a href="@MAC_CLIENTS@"><img src="images/mac_download.png"
-											alt="Mac OS X Client Download" /></a></td>
-								<td align="center">@MAC_CLIENTS_SIZE@</td>
-								<td>@MAC_CLIENTS_BASE@</td>
-								<td align="center">@MAC_CLIENTS_MD5@ (<a href="@MAC_CLIENTS@.md5"
-										>MD5</a>)</td>
-							</tr>
-							<tr>
-								<td><a href="@LINUX_CLIENTS@"><img src="images/linux_download.png"
-											alt="Linux Client Download" /></a></td>
-								<td align="center">@LINUX_CLIENTS_SIZE@</td>
-								<td>@LINUX_CLIENTS_BASE@</td>
-								<td align="center">@LINUX_CLIENTS_MD5@ (<a
-										href="@LINUX_CLIENTS@.md5">MD5</a>)</td>
-							</tr>
-						</tbody>
-					</table>
-				</div>
-				<ul>
-					<li>
-						<p>Each client package includes <a
-								href="@DOC_URL@/users/clients-overview.html#omero-insight"
-								>OMERO.insight</a>, <a
-								href="@DOC_URL@/users/clients-overview.html#omero-importer"
-								>OMERO.importer</a> and <a
-								href="@DOC_URL@/users/clients-overview.html#omero-editor"
-								>OMERO.editor</a> and requires Java Version <strong>1.6</strong> or
-							higher. OMERO.web is part of the server package, so individual users do
-							not need to install it locally.</p>
-					</li>
-					<li>
-						<p>Full instructions for installing the clients are on the Help website: <a
-								href="@HELP_URL@" target="_blank">Getting Started with OMERO.insight
-								Version @VERSION@</a></p>
-					</li>
-				</ul>
-				<h2><a name="plugins" id="plugins"></a>OMERO plugin downloads</h2>
-				<div class="alt-table">
-					<table width="800" border="0" cellpadding="5">
-						<tbody>
-							<tr>
-								<th width="269">Plugins</th>
-								<th width="87">Size</th>
-								<th width="270">File Name</th>
-								<th width="124">Checksum</th>
-							</tr>
-							<tr>
-								<td><a href="@IJ_CLIENTS@"><img src="images/imagej_download.png"
-											alt="ImageJ-Fuji Plugin Download" /></a></td>
-								<td align="center">@IJ_CLIENTS_SIZE@</td>
-								<td>@IJ_CLIENTS_BASE@</td>
-								<td align="center">@IJ_CLIENTS_MD5@ (<a href="@IJ_CLIENTS@.md5"
-										>MD5</a>)</td>
-							</tr>
-							<tr>
-								<td><a href="@MATLAB_CLIENTS@"><img src="images/matlab_download.png"
-											alt="Matlab Plugin Download" /></a></td>
-								<td align="center">@MATLAB_CLIENTS_SIZE@</td>
-								<td>@MATLAB_CLIENTS_BASE@</td>
-								<td align="center">@MATLAB_CLIENTS_MD5@ (<a
-										href="@MATLAB_CLIENTS@.md5">MD5</a>)</td>
-							</tr>
-						</tbody>
-					</table>
-				</div>
-				<ul>
-					<li>
-						<p>Instructions for downloading and installing the ImageJ plugin: <a
-								href="http://help.openmicroscopy.org/imagej.html" target="_blank"
-								>Using ImageJ with OMERO</a></p>
-					</li>
-					<li>
-						<p>Instructions for using the Matlab plugin are at: <a
-								href="@DOC_URL@/developers/Matlab.html">OMERO Matlab language
-								bindings</a></p>
-					</li>
-				</ul>
-				<h2><a name="additional" id="additional"></a>Additional functionality</h2>
-				<ul>
-					<li>
-						<p>Additional clients and plugins developed by our partners in the wider OME
-							consortium are available at: <a
-								href="http://www.openmicroscopy.org/site/products/partner"
-								target="_blank">Partner Projects</a></p>
-					</li>
+                    <li>
+                        <p>Full documentation is available as <a
+                                href="@DOC_URL@">web documentation</a> or <a
+                                href="@DOC@">PDF documentation</a> and there are
+                            user guides for the clients on our <a
+                                href="http://help.openmicroscopy.org">Help
+                                website</a></p>
+                    </li>
+                    <li>
+                        <p>A standard OMERO user just needs to download the
+                            client package with the same major version as their
+                            institutional server e.g. 5.0 clients with the 5.0
+                            server</p>
+                    </li>
+                    <li>
+                        <p>If you do not have an institutional server, you can
+                            apply for an <a
+                                href="http://qa.openmicroscopy.org.uk/registry/demo_account/"
+                                >account on our Demo server</a> or download the
+                                <a href="#va">Virtual Appliance</a> to install
+                            your own version locally.</p>
+                    </li>
+                </ul>
+                <h2><a name="clients" id="clients"></a>OMERO client
+                    downloads</h2>
+                <div class="alt-table">
+                    <table width="800" border="0" cellpadding="5">
+                        <tbody>
+                            <tr>
+                                <th width="269">Clients</th>
+                                <th width="85">Size</th>
+                                <th width="271">File Name</th>
+                                <th width="125">Checksum</th>
+                            </tr>
+                            <tr>
+                                <td><a href="@WIN_CLIENTS@"><img
+                                        src="images/windows_download.png"
+                                        alt="Windows Client Download"
+                                     /></a></td>
+                                <td align="center">@WIN_CLIENTS_SIZE@</td>
+                                <td>@WIN_CLIENTS_BASE@</td>
+                                <td align="center">@WIN_CLIENTS_MD5@ (<a
+                                        href="@WIN_CLIENTS@.md5">MD5</a>)</td>
+                            </tr>
+                            <tr>
+                                <td><a href="@MAC_CLIENTS@"><img
+                                        src="images/mac_download.png"
+                                        alt="Mac OS X Client Download"
+                                     /></a></td>
+                                <td align="center">@MAC_CLIENTS_SIZE@</td>
+                                <td>@MAC_CLIENTS_BASE@</td>
+                                <td align="center">@MAC_CLIENTS_MD5@ (<a
+                                        href="@MAC_CLIENTS@.md5">MD5</a>)</td>
+                            </tr>
+                            <tr>
+                                <td><a href="@LINUX_CLIENTS@"><img
+                                        src="images/linux_download.png"
+                                        alt="Linux Client Download" /></a></td>
+                                <td align="center">@LINUX_CLIENTS_SIZE@</td>
+                                <td>@LINUX_CLIENTS_BASE@</td>
+                                <td align="center">@LINUX_CLIENTS_MD5@ (<a
+                                        href="@LINUX_CLIENTS@.md5">MD5</a>)</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <ul>
+                    <li>
+                        <p>Each client package includes <a
+                                href="@DOC_URL@/users/clients-overview.html#omero-insight"
+                                >OMERO.insight</a>, <a
+                                href="@DOC_URL@/users/clients-overview.html#omero-importer"
+                                >OMERO.importer</a> and <a
+                                href="@DOC_URL@/users/clients-overview.html#omero-editor"
+                                >OMERO.editor</a> and requires Java Version
+                                <strong>1.6</strong> or higher. OMERO.web is
+                            part of the server package, so individual users do
+                            not need to install it locally.</p>
+                    </li>
+                    <li>
+                        <p>Full instructions for installing the clients are on
+                            the Help website: <a href="@HELP_URL@"
+                                target="_blank">Getting Started with
+                                OMERO.insight Version @VERSION@</a></p>
+                    </li>
+                </ul>
+                <h2><a name="plugins" id="plugins"></a>OMERO plugin
+                    downloads</h2>
+                <div class="alt-table">
+                    <table width="800" border="0" cellpadding="5">
+                        <tbody>
+                            <tr>
+                                <th width="269">Plugins</th>
+                                <th width="87">Size</th>
+                                <th width="270">File Name</th>
+                                <th width="124">Checksum</th>
+                            </tr>
+                            <tr>
+                                <td><a href="@IJ_CLIENTS@"><img
+                                        src="images/imagej_download.png"
+                                        alt="ImageJ-Fuji Plugin Download"
+                                     /></a></td>
+                                <td align="center">@IJ_CLIENTS_SIZE@</td>
+                                <td>@IJ_CLIENTS_BASE@</td>
+                                <td align="center">@IJ_CLIENTS_MD5@ (<a
+                                        href="@IJ_CLIENTS@.md5">MD5</a>)</td>
+                            </tr>
+                            <tr>
+                                <td><a href="@MATLAB_CLIENTS@"><img
+                                        src="images/matlab_download.png"
+                                        alt="Matlab Plugin Download" /></a></td>
+                                <td align="center">@MATLAB_CLIENTS_SIZE@</td>
+                                <td>@MATLAB_CLIENTS_BASE@</td>
+                                <td align="center">@MATLAB_CLIENTS_MD5@ (<a
+                                        href="@MATLAB_CLIENTS@.md5"
+                                    >MD5</a>)</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <ul>
+                    <li>
+                        <p>Instructions for downloading and installing the
+                            ImageJ plugin: <a
+                                href="http://help.openmicroscopy.org/imagej.html"
+                                target="_blank">Using ImageJ with OMERO</a></p>
+                    </li>
+                    <li>
+                        <p>Instructions for using the Matlab plugin are at: <a
+                                href="@DOC_URL@/developers/Matlab.html">OMERO
+                                Matlab language bindings</a></p>
+                    </li>
+                </ul>
+                <h2><a name="additional" id="additional"></a>Additional
+                    functionality</h2>
+                <ul>
+                    <li>
+                        <p>Additional clients and plugins developed by our
+                            partners in the wider OME consortium are available
+                            at: <a
+                                href="http://www.openmicroscopy.org/site/products/partner"
+                                target="_blank">Partner Projects</a></p>
+                    </li>
 
-					<li>
-						<p>The functionality of the existing OMERO clients can be extended using
-							scripts, for details and scripts see: <a
-								href="http://www.openmicroscopy.org/site/community/scripts"
-								target="_blank">Script Sharing</a></p>
-					</li>
-				</ul>
-				<h2><a name="servers" id="servers"></a>OMERO server @VERSION@ downloads</h2>
-				<div class="alt-table">
-					<table width="800" border="0" cellpadding="5">
-						<tbody>
-							<tr>
-								<th width="269">Servers</th>
-								<th width="89">Size</th>
-								<th width="270">File Name</th>
-								<th width="122">Checksum</th>
-							</tr>
-							<tr>
-								<td><a href="@SERVER33@"><img src="images/ice3_3_download.png"
-											alt="Ice 3.3 Server Download" /></a></td>
-								<td align="center">@SERVER33_SIZE@</td>
-								<td>@SERVER33_BASE@</td>
-								<td align="center">@SERVER33_MD5@ (<a href="@SERVER33@.md5"
-									>MD5</a>)</td>
-							</tr>
-							<tr>
-								<td><a href="@SERVER34@"><img src="images/ice3_4_download.png"
-											alt="Ice 3.4 Server Download" /></a></td>
-								<td align="center">@SERVER34_SIZE@</td>
-								<td>@SERVER34_BASE@</td>
-								<td align="center">@SERVER34_MD5@ (<a href="@SERVER34@.md5"
-									>MD5</a>)</td>
-							</tr>
-							<tr>
-								<td><a href="@SERVER35@"><img src="images/ice3_5_download_linux.png"
-											alt="Ice 3.5 Server Download" /></a></td>
-								<td align="center">@SERVER35_SIZE@</td>
-								<td>@SERVER35_BASE@</td>
-								<td align="center">@SERVER35_MD5@ (<a href="@SERVER35@.md5"
-									>MD5</a>)</td>
-							</tr>
-						</tbody>
-					</table>
-				</div>
-				<ul>
-					<li>
-						<p>If you are using Windows, we recommend you default to using OMERO.server
-							with Ice 3.4. The Ice 3.5 server is not supported on Windows because Ice
-							3.5 requires Python 3, which OMERO does not yet support (see the <a
-								href="@DOC_URL@/sysadmins/limitations.html#windows-os-issues">Known
-								Limitations</a> page for more detail)</p>
-					</li>
-					<li>
-						<p>Download the server matching the Ice version you are using (note that the
-							client(s) should work with any version of the server)</p>
-					</li>
-					<li>
-						<p>Installation instructions are available for: <a
-								href="@DOC_URL@/sysadmins/unix/server-installation.html">Unix
-								platforms</a>, <a
-								href="@DOC_URL@/sysadmins/windows/server-installation.html"
-								>Microsoft Windows</a>
-						</p>
-					</li>
-					<li>
-						<p>Server upgrade instructions are at: <a
-								href="@DOC_URL@/sysadmins/server-upgrade.html">OMERO.server
-								upgrade</a></p>
-					</li>
-				</ul>
-				<h2><a name="va" id="va"></a>OMERO Virtual Appliance download</h2>
-				<div class="alt-table">
-					<table width="800" border="0" cellpadding="5">
-						<tbody>
-							<tr>
-								<th width="269">Virtual Appliance</th>
-								<th width="91">Size</th>
-								<th width="270">File Name</th>
-								<th width="120">Checksum</th>
-							</tr>
-							<tr>
-								<td><a href="@VM@"><img src="images/virtual_app_download.png"
-											alt="Virtual Appliance Download" /></a></td>
-								<td align="center">@VM_SIZE@</td>
-								<td>@VM_BASE@</td>
-								<td align="center">@VM_MD5@ (<a href="@VM@.md5">MD5</a>)</td>
-							</tr>
-						</tbody>
-					</table>
-				</div>
-				<ul>
-					<li>
-						<p>The OMERO Virtual Appliance allows you to try out an OMERO server on your
-							local machine </p>
-					</li>
-					<li>
-						<p>Instructions for using the Virtual Appliance are at: <a
-								href="@DOC_URL@/users/virtual-appliance.html">Virtual
-							Appliance</a></p>
-					</li>
-				</ul>
-				<h2><a name="api" id="api"></a>OMERO API documentation</h2>
-				<div class="alt-table">
-					<table width="800" border="0" cellpadding="5">
-						<tbody>
-							<tr>
-								<th width="269">API Documentation</th>
-								<th width="92">Size</th>
-								<th width="271">File Name</th>
-								<th width="118">MD5 Checksum</th>
-							</tr>
-							<tr>
-								<td><a href="@DOCS@"><img src="images/api_download.png"
-											alt="API Documentation Download" /></a></td>
-								<td align="center">@DOCS_SIZE@</td>
-								<td>@DOCS_BASE@</td>
-								<td align="center">@DOCS_MD5@ (<a href="@DOCS@.md5">MD5</a>)</td>
-							</tr>
-						</tbody>
-					</table>
-				</div>
-				<ul>
-					<li>
-						<p>The OMERO API documentation is also available to read on the web <a
-								href="api">here</a></p>
-					</li>
-					<li>
-						<p>Zipped files of API documentation for other versions of Ice are available
-							as part of the <a href="#components">build components</a></p>
-					</li>
-				</ul>
-				<h2><a name="code" id="code"></a>Checking out the code</h2>
-				<div class="alt-table">
-					<table width="800" border="0" cellpadding="5">
-						<tbody>
-							<tr>
-								<th width="269">Source Code</th>
-								<th width="91">Size</th>
-								<th width="270">File Name</th>
-								<th width="120">Checksum</th>
-							</tr>
-							<tr>
-								<td><a href="@SOURCE_CODE@" target="_blank"><img
-											src="images/ome_source_code.png"
-											alt="Zipped Source Code" /></a></td>
-								<td align="center">@SOURCE_CODE_SIZE@</td>
-								<td>@SOURCE_CODE_BASE@</td>
-								<td align="center">@SOURCE_CODE_MD5@ (<a href="@SOURCE_CODE@.md5"
-										>MD5</a>)</td>
-							</tr>
-						</tbody>
-					</table>
-				</div>
-				<div class="alt-table">
-					<table width="278" border="0" cellpadding="5">
-						<tbody>
-							<tr>
-								<th width="264">Source Code Links</th>
-							</tr>
-							<tr>
-								<td><a href="http://github.com/openmicroscopy/openmicroscopy"
-										target="_blank"><img src="images/github_rep_link.png"
-											alt="GitHub Repository Link" /></a></td>
-							</tr>
-							<tr>
-								<td><a href="http://git.openmicroscopy.org/" target="_blank"><img
-											src="images/gitweb_int_link.png"
-											alt="Gitweb Interface Link" /></a></td>
-							</tr>
-							<tr>
-								<td><a href="@TAG_URL@" target="_blank"><img
-											src="images/git_tag.png" alt="GitHub Tag" /></a></td>
-							</tr>
-						</tbody>
-					</table>
-				</div>
-				<ul>
-					<li>
-						<p>Instructions for installing the source code can be found at: <a
-								href="@DOC_URL@/developers/installation.html" target="_blank"
-								>Installing OMERO from source</a></p>
-					</li>
-				</ul>
-				<h2><a name="components" id="components"></a><a name="artifacts" id="artifacts"
-					></a>Download components</h2>
-				<ul>
-					<li>
-						<p>All components available for this version of OMERO are available <a
-								href="artifacts">here</a></p>
-					</li>
-				</ul>
-				<h2><a name="previous" id="previous"></a>Previous versions</h2>
-				<ul>
-					<li>
-						<p>We recommend that you always use the most recent release version of the
-							OMERO software, but if you need to use a previous version, they are all
-							available from the main <a
-								href="http://downloads.openmicroscopy.org/omero/?C=M;O=D">downloads
-								folder</a></p>
-					</li>
-				</ul>
-			</div><!-- /.entry-content -->
-			<!-- </section>  -->
-			<!-- <footer id="contentinfo" class="body">
+                    <li>
+                        <p>The functionality of the existing OMERO clients can
+                            be extended using scripts, for details and scripts
+                            see: <a
+                                href="http://www.openmicroscopy.org/site/community/scripts"
+                                target="_blank">Script Sharing</a></p>
+                    </li>
+                </ul>
+                <h2><a name="servers" id="servers"></a>OMERO server @VERSION@
+                    downloads</h2>
+                <div class="alt-table">
+                    <table width="800" border="0" cellpadding="5">
+                        <tbody>
+                            <tr>
+                                <th width="269">Servers</th>
+                                <th width="89">Size</th>
+                                <th width="270">File Name</th>
+                                <th width="122">Checksum</th>
+                            </tr>
+                            <tr>
+                                <td><a href="@SERVER33@"><img
+                                        src="images/ice3_3_download.png"
+                                        alt="Ice 3.3 Server Download"
+                                     /></a></td>
+                                <td align="center">@SERVER33_SIZE@</td>
+                                <td>@SERVER33_BASE@</td>
+                                <td align="center">@SERVER33_MD5@ (<a
+                                        href="@SERVER33@.md5">MD5</a>)</td>
+                            </tr>
+                            <tr>
+                                <td><a href="@SERVER34@"><img
+                                        src="images/ice3_4_download.png"
+                                        alt="Ice 3.4 Server Download"
+                                     /></a></td>
+                                <td align="center">@SERVER34_SIZE@</td>
+                                <td>@SERVER34_BASE@</td>
+                                <td align="center">@SERVER34_MD5@ (<a
+                                        href="@SERVER34@.md5">MD5</a>)</td>
+                            </tr>
+                            <tr>
+                                <td><a href="@SERVER35@"><img
+                                        src="images/ice3_5_download_linux.png"
+                                        alt="Ice 3.5 Server Download"
+                                     /></a></td>
+                                <td align="center">@SERVER35_SIZE@</td>
+                                <td>@SERVER35_BASE@</td>
+                                <td align="center">@SERVER35_MD5@ (<a
+                                        href="@SERVER35@.md5">MD5</a>)</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <ul>
+                    <li>
+                        <p>If you are using Windows, we recommend you default to
+                            using OMERO.server with Ice 3.4. The Ice 3.5 server
+                            is not supported on Windows because Ice 3.5 requires
+                            Python 3, which OMERO does not yet support (see the
+                                <a
+                                href="@DOC_URL@/sysadmins/limitations.html#windows-os-issues"
+                                >Known Limitations</a> page for more detail)</p>
+                    </li>
+                    <li>
+                        <p>Download the server matching the Ice version you are
+                            using (note that the client(s) should work with any
+                            version of the server)</p>
+                    </li>
+                    <li>
+                        <p>Installation instructions are available for: <a
+                                href="@DOC_URL@/sysadmins/unix/server-installation.html"
+                                >Unix platforms</a>, <a
+                                href="@DOC_URL@/sysadmins/windows/server-installation.html"
+                                >Microsoft Windows</a>
+                        </p>
+                    </li>
+                    <li>
+                        <p>Server upgrade instructions are at: <a
+                                href="@DOC_URL@/sysadmins/server-upgrade.html"
+                                >OMERO.server upgrade</a></p>
+                    </li>
+                </ul>
+                <h2><a name="va" id="va"></a>OMERO Virtual Appliance
+                    download</h2>
+                <div class="alt-table">
+                    <table width="800" border="0" cellpadding="5">
+                        <tbody>
+                            <tr>
+                                <th width="269">Virtual Appliance</th>
+                                <th width="91">Size</th>
+                                <th width="270">File Name</th>
+                                <th width="120">Checksum</th>
+                            </tr>
+                            <tr>
+                                <td><a href="@VM@"><img
+                                        src="images/virtual_app_download.png"
+                                        alt="Virtual Appliance Download"
+                                     /></a></td>
+                                <td align="center">@VM_SIZE@</td>
+                                <td>@VM_BASE@</td>
+                                <td align="center">@VM_MD5@ (<a href="@VM@.md5"
+                                        >MD5</a>)</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <ul>
+                    <li>
+                        <p>The OMERO Virtual Appliance allows you to try out an
+                            OMERO server on your local machine </p>
+                    </li>
+                    <li>
+                        <p>Instructions for using the Virtual Appliance are at:
+                                <a href="@DOC_URL@/users/virtual-appliance.html"
+                                >Virtual Appliance</a></p>
+                    </li>
+                </ul>
+                <h2><a name="api" id="api"></a>OMERO API documentation</h2>
+                <div class="alt-table">
+                    <table width="800" border="0" cellpadding="5">
+                        <tbody>
+                            <tr>
+                                <th width="269">API Documentation</th>
+                                <th width="92">Size</th>
+                                <th width="271">File Name</th>
+                                <th width="118">MD5 Checksum</th>
+                            </tr>
+                            <tr>
+                                <td><a href="@DOCS@"><img
+                                        src="images/api_download.png"
+                                        alt="API Documentation Download"
+                                     /></a></td>
+                                <td align="center">@DOCS_SIZE@</td>
+                                <td>@DOCS_BASE@</td>
+                                <td align="center">@DOCS_MD5@ (<a
+                                        href="@DOCS@.md5">MD5</a>)</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <ul>
+                    <li>
+                        <p>The OMERO API documentation is also available to read
+                            on the web <a href="api">here</a></p>
+                    </li>
+                    <li>
+                        <p>Zipped files of API documentation for other versions
+                            of Ice are available as part of the <a
+                                href="#components">build components</a></p>
+                    </li>
+                </ul>
+                <h2><a name="code" id="code"></a>Checking out the code</h2>
+                <div class="alt-table">
+                    <table width="800" border="0" cellpadding="5">
+                        <tbody>
+                            <tr>
+                                <th width="269">Source Code</th>
+                                <th width="91">Size</th>
+                                <th width="270">File Name</th>
+                                <th width="120">Checksum</th>
+                            </tr>
+                            <tr>
+                                <td><a href="@SOURCE_CODE@" target="_blank"><img
+                                        src="images/ome_source_code.png"
+                                        alt="Zipped Source Code" /></a></td>
+                                <td align="center">@SOURCE_CODE_SIZE@</td>
+                                <td>@SOURCE_CODE_BASE@</td>
+                                <td align="center">@SOURCE_CODE_MD5@ (<a
+                                        href="@SOURCE_CODE@.md5">MD5</a>)</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <div class="alt-table">
+                    <table width="278" border="0" cellpadding="5">
+                        <tbody>
+                            <tr>
+                                <th width="264">Source Code Links</th>
+                            </tr>
+                            <tr>
+                                <td><a
+                                        href="http://github.com/openmicroscopy/openmicroscopy"
+                                        target="_blank"><img
+                                        src="images/github_rep_link.png"
+                                        alt="GitHub Repository Link" /></a></td>
+                            </tr>
+                            <tr>
+                                <td><a href="http://git.openmicroscopy.org/"
+                                        target="_blank"><img
+                                        src="images/gitweb_int_link.png"
+                                        alt="Gitweb Interface Link" /></a></td>
+                            </tr>
+                            <tr>
+                                <td><a href="@TAG_URL@" target="_blank"><img
+                                        src="images/git_tag.png"
+                                        alt="GitHub Tag" /></a></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <ul>
+                    <li>
+                        <p>Instructions for installing the source code can be
+                            found at: <a
+                                href="@DOC_URL@/developers/installation.html"
+                                target="_blank">Installing OMERO from
+                            source</a></p>
+                    </li>
+                </ul>
+                <h2><a name="components" id="components"></a><a name="artifacts"
+                        id="artifacts"></a>Download components</h2>
+                <ul>
+                    <li>
+                        <p>All components available for this version of OMERO
+                            are available <a href="artifacts">here</a></p>
+                    </li>
+                </ul>
+                <h2><a name="previous" id="previous"></a>Previous versions</h2>
+                <ul>
+                    <li>
+                        <p>We recommend that you always use the most recent
+                            release version of the OMERO software, but if you
+                            need to use a previous version, they are all
+                            available from the main <a
+                                href="http://downloads.openmicroscopy.org/omero/?C=M;O=D"
+                                >downloads folder</a></p>
+                    </li>
+                </ul>
+            </div><!-- /.entry-content -->
+            <!-- </section>  -->
+            <!-- <footer id="contentinfo" class="body">
 			</footer> --><!-- /#contentinfo -->
-			<!-- OME Footer - Start -->
-			<div class="visualClear" id="clear-space-before-footer"><!-- --></div>
-			<div id="portal-footer">
-				<p>
-					<acronym title="Copyright">&copy;</acronym> 2000-2014 University of Dundee &amp;
-					Open Microscopy Environment. <a
-						href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
-						>Creative Commons Attribution 3.0 Unported License</a>
-				</p>
-				<p> OME source code is available under the <a
-						href="http://www.openmicroscopy.org/site/about/licensing">GNU General public
-						license</a> or through commercial license from <a
-						href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software"
-						>Glencoe Software</a>
-				</p>
-			</div>
-			<div class="visualClear">
-				<!-- OME Footer - END -->
-			</div>
-		</div>
-	</body>
+            <!-- OME Footer - Start -->
+            <div class="visualClear" id="clear-space-before-footer"
+                ><!-- --></div>
+            <div id="portal-footer">
+                <p>
+                    <acronym title="Copyright">&copy;</acronym> 2000-2014
+                    University of Dundee &amp; Open Microscopy Environment. <a
+                        href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
+                        >Creative Commons Attribution 3.0 Unported License</a>
+                </p>
+                <p> OME source code is available under the <a
+                        href="http://www.openmicroscopy.org/site/about/licensing"
+                        >GNU General public license</a> or through commercial
+                    license from <a
+                        href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software"
+                        >Glencoe Software</a>
+                </p>
+            </div>
+            <div class="visualClear">
+                <!-- OME Footer - END -->
+            </div>
+        </div>
+    </body>
 </html>

--- a/omero_downloads.html
+++ b/omero_downloads.html
@@ -1,351 +1,425 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 
-        <link rel="stylesheet" href="images/plonematch.css" type="text/css">
-        <meta charset="utf-8">
+		<link rel="stylesheet" href="images/plonematch.css" type="text/css" />
 
+		<style type="text/css">
+			[touch-action = "none"]{
+				-ms-touch-action:none;
+				touch-action:none;
+			}
+			[touch-action = "pan-x"]{
+				-ms-touch-action:pan-x;
+				touch-action:pan-x;
+			}
+			[touch-action = "pan-y"]{
+				-ms-touch-action:pan-y;
+				touch-action:pan-y;
+			}
+			[touch-action = "scroll"],
+			[touch-action = "pan-x pan-y"],
+			[touch-action = "pan-y pan-x"]{
+				-ms-touch-action:pan-x pan-y;
+				touch-action:pan-x pan-y;
+			}</style>
+		<title></title>
+	</head>
 
-      <meta name="tags" contents="omero">
-      <meta name="tags" contents="downloads">
-
-    <style type="text/css"></style><style>[touch-action="none"]{ -ms-touch-action: none; touch-action: none; }[touch-action="pan-x"]{ -ms-touch-action: pan-x; touch-action: pan-x; }[touch-action="pan-y"]{ -ms-touch-action: pan-y; touch-action: pan-y; }[touch-action="scroll"],[touch-action="pan-x pan-y"],[touch-action="pan-y pan-x"]{ -ms-touch-action: pan-x pan-y; touch-action: pan-x pan-y; }</style></head>
-    <body id="index" class="home">
-
+	<body id="index" class="home">
 		<!-- OME Banner - START -->
 		<div id="portal-top">
 			<div id="portal-header">
 				<ul id="portal-siteactions">
 					<li>
-						<br>
+						<br />
 					</li>
-				</ul><a id="portal-logo" accesskey="1" href="http://downloads.openmicroscopy.org/" name="portal-logo"><img src="images/logo.jpg" alt="" title="" height="73" width="450"></a>
-			  <div id="portal-globalnav">
-					<br>
+				</ul><a id="portal-logo" accesskey="1" href="http://downloads.openmicroscopy.org/"
+					name="portal-logo"><img src="images/logo.jpg" alt="" title="" height="73"
+						width="450" /></a>
+				<div id="portal-globalnav">
+					<br />
 				</div>
 			</div>
 			<div id="portal-personaltools-wrapper">
 				<ul id="portal-personaltools" class="visualInline">
 					<li>
-						<br>
+						<br />
 					</li>
 				</ul>
 			</div>
 		</div>
 		<div class="visualClear" id="clear-space-before-wrapper-table">
-		<!-- OME Banner - END -->
+			<!-- OME Banner - END -->
+			<!-- /#menu -->
+			<!-- <section id="content" class="body" style="margin-left:20px;"> -->
+			<div class="entry-content">
+				<h2>OMERO @VERSION@ Downloads</h2>
+				<p>
+					<strong><a href="#clients">Clients</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
+							href="#plugins">Plugins</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
+							href="#additional">Additional</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
+							href="#servers">Servers</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#va"
+							>Virtual Appliance</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#api"
+							>API</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#code"
+							>Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#components"
+							>Components</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#previous">Previous
+							versions</a>
+					</strong></p>
+				<ul>
+					<li>
+						<p>Information on this release of OMERO is in the <a
+								href="@ANNOUCEMENT_URL@">release announcement</a></p>
+					</li>
 
-                                  <!-- /#menu -->
-<section id="content" class="body" style="margin-left:20px;">
+					<li>
+						<p>Full documentation is available as <a href="@DOC_URL@">web
+								documentation</a> or <a href="@DOC@">PDF documentation</a> and there
+							are user guides for the clients on our <a
+								href="http://help.openmicroscopy.org">Help website</a></p>
+					</li>
+					<li>
+						<p>A standard OMERO user just needs to download the client package with the
+							same major version as their institutional server e.g. 5.0 clients with
+							the 5.0 server</p>
+					</li>
+					<li>
+						<p>If you do not have an institutional server, you can apply for an <a
+								href="http://qa.openmicroscopy.org.uk/registry/demo_account/"
+								>account on our Demo server</a> or download the <a href="#va"
+								>Virtual Appliance</a> to install your own version locally.</p>
+					</li>
+				</ul>
+				<h2><a name="clients" id="clients"></a>OMERO client downloads</h2>
+				<div class="alt-table">
+					<table width="800" border="0" cellpadding="5">
+						<tbody>
+							<tr>
+								<th width="269">Clients</th>
+								<th width="85">Size</th>
+								<th width="271">File Name</th>
+								<th width="125">Checksum</th>
+							</tr>
+							<tr>
+								<td><a href="@WIN_CLIENTS@"><img src="images/windows_download.png"
+											alt="Windows Client Download" /></a></td>
+								<td align="center">@WIN_CLIENTS_SIZE@</td>
+								<td>@WIN_CLIENTS_BASE@</td>
+								<td align="center">@WIN_CLIENTS_MD5@ (<a href="@WIN_CLIENTS@.md5"
+										>MD5</a>)</td>
+							</tr>
+							<tr>
+								<td><a href="@MAC_CLIENTS@"><img src="images/mac_download.png"
+											alt="Mac OS X Client Download" /></a></td>
+								<td align="center">@MAC_CLIENTS_SIZE@</td>
+								<td>@MAC_CLIENTS_BASE@</td>
+								<td align="center">@MAC_CLIENTS_MD5@ (<a href="@MAC_CLIENTS@.md5"
+										>MD5</a>)</td>
+							</tr>
+							<tr>
+								<td><a href="@LINUX_CLIENTS@"><img src="images/linux_download.png"
+											alt="Linux Client Download" /></a></td>
+								<td align="center">@LINUX_CLIENTS_SIZE@</td>
+								<td>@LINUX_CLIENTS_BASE@</td>
+								<td align="center">@LINUX_CLIENTS_MD5@ (<a
+										href="@LINUX_CLIENTS@.md5">MD5</a>)</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<ul>
+					<li>
+						<p>Each client package includes <a
+								href="@DOC_URL@/users/clients-overview.html#omero-insight"
+								>OMERO.insight</a>, <a
+								href="@DOC_URL@/users/clients-overview.html#omero-importer"
+								>OMERO.importer</a> and <a
+								href="@DOC_URL@/users/clients-overview.html#omero-editor"
+								>OMERO.editor</a> and requires Java Version <strong>1.6</strong> or
+							higher. OMERO.web is part of the server package, so individual users do
+							not need to install it locally.</p>
+					</li>
+					<li>
+						<p>Full instructions for installing the clients are on the Help website: <a
+								href="@HELP_URL@" target="_blank">Getting Started with OMERO.insight
+								Version @VERSION@</a></p>
+					</li>
+				</ul>
+				<h2><a name="plugins" id="plugins"></a>OMERO plugin downloads</h2>
+				<div class="alt-table">
+					<table width="800" border="0" cellpadding="5">
+						<tbody>
+							<tr>
+								<th width="269">Plugins</th>
+								<th width="87">Size</th>
+								<th width="270">File Name</th>
+								<th width="124">Checksum</th>
+							</tr>
+							<tr>
+								<td><a href="@IJ_CLIENTS@"><img src="images/imagej_download.png"
+											alt="ImageJ-Fuji Plugin Download" /></a></td>
+								<td align="center">@IJ_CLIENTS_SIZE@</td>
+								<td>@IJ_CLIENTS_BASE@</td>
+								<td align="center">@IJ_CLIENTS_MD5@ (<a href="@IJ_CLIENTS@.md5"
+										>MD5</a>)</td>
+							</tr>
+							<tr>
+								<td><a href="@MATLAB_CLIENTS@"><img src="images/matlab_download.png"
+											alt="Matlab Plugin Download" /></a></td>
+								<td align="center">@MATLAB_CLIENTS_SIZE@</td>
+								<td>@MATLAB_CLIENTS_BASE@</td>
+								<td align="center">@MATLAB_CLIENTS_MD5@ (<a
+										href="@MATLAB_CLIENTS@.md5">MD5</a>)</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<ul>
+					<li>
+						<p>Instructions for downloading and installing the ImageJ plugin: <a
+								href="http://help.openmicroscopy.org/imagej.html" target="_blank"
+								>Using ImageJ with OMERO</a></p>
+					</li>
+					<li>
+						<p>Instructions for using the Matlab plugin are at: <a
+								href="@DOC_URL@/developers/Matlab.html">OMERO Matlab language
+								bindings</a></p>
+					</li>
+				</ul>
+				<h2><a name="additional" id="additional"></a>Additional functionality</h2>
+				<ul>
+					<li>
+						<p>Additional clients and plugins developed by our partners in the wider OME
+							consortium are available at: <a
+								href="http://www.openmicroscopy.org/site/products/partner"
+								target="_blank">Partner Projects</a></p>
+					</li>
 
-<div class="entry-content">
-
-<h2>OMERO @VERSION@ Downloads</h2>
-
-<p>
-  <strong><a href="#clients">Clients</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#plugins">Plugins</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#additional">Additional</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#servers">Servers</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#va">Virtual Appliance</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#api">API</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#code">Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#components">Components</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#previous">Previous versions</a> </strong></p>
-
-<ul>
-<li>
-<p>Information on this release of OMERO is in the  <a href="@ANNOUCEMENT_URL@">release announcement</a></p>
-</li>
-
-<li>
-<p>Full documentation is available as <a href="@DOC_URL@">web documentation</a>  or
-<a href="@DOC@">PDF documentation</a> and there are user guides for the clients on our <a href="http://help.openmicroscopy.org">Help website</a></p>
-</li>
-<li>
-<p>A standard OMERO user just needs to download the client package with the same major version as their institutional server  e.g. 5.0
-clients with the 5.0 server</p>
-</li>
-<li>
-<p>If you do not have an institutional server, you can apply for an <a href="http://qa.openmicroscopy.org.uk/registry/demo_account/">account on our Demo server</a> or download the <a href="#va">Virtual Appliance</a> to install your own version locally.</p>
-</li>
-</ul>
-
-
-<h2><a name="clients" id="clients"></a>OMERO client downloads</h2>
-<div class="alt-table">
-  <table width="800" border="0" cellpadding="5">
-    <tbody>
-      <tr>
-        <th width="269">Clients</th>
-        <th width="85">Size</th>
-        <th width="271">File Name</th>
-        <th width="125">Checksum</th>
-        </tr>
-      <tr>
-        <td><a href="@WIN_CLIENTS@"><img src="images/windows_download.png" alt="Windows Client Download" /></a></td>
-        <td align="center">@WIN_CLIENTS_SIZE@</td>
-        <td>@WIN_CLIENTS_BASE@</td>
-        <td align="center">@WIN_CLIENTS_MD5@ (<a href="@WIN_CLIENTS@.md5">MD5</a>)</td>
-      </tr>
-      <tr>
-        <td><a href="@MAC_CLIENTS@"><img src="images/mac_download.png" alt="Mac OS X Client Download" /></a></td>
-        <td align="center">@MAC_CLIENTS_SIZE@</td>
-        <td>@MAC_CLIENTS_BASE@</td>
-        <td align="center">@MAC_CLIENTS_MD5@ (<a href="@MAC_CLIENTS@.md5">MD5</a>)</td>
-        </tr>
-      <tr>
-        <td><a href="@LINUX_CLIENTS@"><img src="images/linux_download.png" alt="Linux Client Download" /></a></td>
-        <td align="center">@LINUX_CLIENTS_SIZE@</td>
-        <td>@LINUX_CLIENTS_BASE@</td>
-        <td align="center">@LINUX_CLIENTS_MD5@ (<a href="@LINUX_CLIENTS@.md5">MD5</a>)</td>
-        </tr>
-    </tbody>
-  </table>
-</div>
-
-<ul>
-<li>
-<p>Each client package includes
-<a href="@DOC_URL@/users/clients-overview.html#omero-insight">OMERO.insight</a>,
-<a href="@DOC_URL@/users/clients-overview.html#omero-importer">OMERO.importer</a> and
-<a href="@DOC_URL@/users/clients-overview.html#omero-editor">OMERO.editor</a> and requires
-Java Version <strong>1.6</strong> or higher. OMERO.web is part of the server package, so individual users do not need to install it locally.</p>
-</li>
-<li>
-<p>Full instructions for installing the clients are on the Help website: <a href="@HELP_URL@" target="_blank">Getting Started with OMERO.insight Version @VERSION@</a></p>
-</li>
-</ul>
-
-<h2><a name="plugins" id="plugins"></a>OMERO plugin downloads</h2>
-
-<div class="alt-table">
-  <table width="800" border="0" cellpadding="5">
-    <tbody>
-      <tr>
-        <th width="269">Plugins</th>
-        <th width="87">Size</th>
-        <th width="270">File Name</th>
-        <th width="124">Checksum</th>
-        </tr>
-      <tr>
-        <td><a href="@IJ_CLIENTS@"><img src="images/imagej_download.png" alt="ImageJ-Fuji Plugin Download" /></a></td>
-        <td align="center">@IJ_CLIENTS_SIZE@</td>
-        <td>@IJ_CLIENTS_BASE@</td>
-        <td align="center">@IJ_CLIENTS_MD5@ (<a href="@IJ_CLIENTS@.md5">MD5</a>)</td>
-        </tr>
-      <tr>
-        <td><a href="@MATLAB_CLIENTS@"><img src="images/matlab_download.png" alt="Matlab Plugin Download" /></a></td>
-        <td align="center">@MATLAB_CLIENTS_SIZE@</td>
-        <td>@MATLAB_CLIENTS_BASE@</td>
-        <td align="center">@MATLAB_CLIENTS_MD5@ (<a href="@MATLAB_CLIENTS@.md5">MD5</a>)</td>
-        </tr>
-    </tbody>
-  </table>
-</div>
-
-<ul>
-<li>
-<p>Instructions for downloading and installing the ImageJ plugin: <a href="http://help.openmicroscopy.org/imagej.html" target="_blank">Using ImageJ with OMERO</a></p>
-</li>
-<li>
-<p>Instructions for using the Matlab plugin are at:
-<a href="@DOC_URL@/developers/Matlab.html">OMERO Matlab language bindings</a></p>
-</li>
-</ul>
-
-
-<h2><a name="additional" id="additional"></a>Additional functionality</h2>
-
-<ul>
-  <li>
-<p>Additional clients and plugins developed by our partners in the wider OME consortium are available at: <a href="http://www.openmicroscopy.org/site/products/partner" target="_blank">Partner Projects</a></a></p>
-  </li>
-
-  <li>
-<p>The functionality of the existing OMERO clients can be extended using scripts, for details and scripts see: <a href="http://www.openmicroscopy.org/site/community/scripts" target="_blank">Script Sharing</a></a></p>
-  </li>
-</ul>
-
-<h2><a name="servers" id="servers"></a>OMERO server @VERSION@ downloads</h2>
-<div class="alt-table">
-<table width="800" border="0" cellpadding="5">
-  <tbody>
-    <tr>
-      <th width="269">Servers</th>
-      <th width="89">Size</th>
-      <th width="270">File Name</th>
-      <th width="122">Checksum</th>
-      </tr>
-    <tr>
-      <td><a href="@SERVER33@"><img src="images/ice3_3_download.png" alt="Ice 3.3 Server Download" /></a></td>
-      <td align="center">@SERVER33_SIZE@</td>
-      <td>@SERVER33_BASE@</td>
-      <td align="center">@SERVER33_MD5@ (<a href="@SERVER33@.md5">MD5</a>)</td>
-      </tr>
-    <tr>
-      <td><a href="@SERVER34@"><img src="images/ice3_4_download.png" alt="Ice 3.4 Server Download" /></a></td>
-      <td align="center">@SERVER34_SIZE@</td>
-      <td>@SERVER34_BASE@</td>
-      <td align="center">@SERVER34_MD5@ (<a href="@SERVER34@.md5">MD5</a>)</td>
-      </tr>
-    <tr>
-      <td><a href="@SERVER35@"><img src="images/ice3_5_download_linux.png" alt="Ice 3.5 Server Download" /></a></td>
-      <td align="center">@SERVER35_SIZE@</td>
-      <td>@SERVER35_BASE@</td>
-      <td align="center">@SERVER35_MD5@ (<a href="@SERVER35@.md5">MD5</a>)</td>
-      </tr>
-  </tbody>
-</table>
-</div>
-
-<ul>
-<li>
-<p>If you are using Windows, we recommend you default to using OMERO.server with Ice 3.4. The Ice 3.5 server is not supported on Windows because Ice 3.5 requires Python 3, which OMERO does not yet support (see the <a href="@DOC_URL@/sysadmins/limitations.html#windows-os-issues">Known Limitations</a> page for more detail)</p>
-<li>
-<p>Download the
-  server matching  the Ice version you are using (note that the client(s)
-  should work with any version of the server)</p>
-</li>
-<li>
-<p>Installation instructions are available for: <a href="@DOC_URL@/sysadmins/unix/server-installation.html">Unix
-platforms</a>, <a href="@DOC_URL@/sysadmins/windows/server-installation.html">Microsoft
-Windows</a> </p>
-</li>
-<li>
-  <p>Server upgrade instructions are at: <a href="@DOC_URL@/sysadmins/server-upgrade.html">OMERO.server upgrade</a></p>
-</ul>
-
-
-<h2><a name="va" id="va"></a>OMERO Virtual Appliance download</h2>
-<div class="alt-table">
-<table width="800" border="0" cellpadding="5">
-  <tbody>
-    <tr>
-      <th width="269">Virtual Appliance</th>
-      <th width="91">Size</th>
-      <th width="270">File Name</th>
-      <th width="120">Checksum</th>
-      </tr>
-    <tr>
-      <td><a href="@VM@"><img src="images/virtual_app_download.png" alt="Virtual Appliance Download" /></a></td>
-      <td align="center">@VM_SIZE@</td>
-      <td>@VM_BASE@</td>
-      <td align="center">@VM_MD5@ (<a href="@VM@.md5">MD5</a>)</td>
-      </tr>
-  </tbody>
-</table>
-</div>
-
-<ul>
-  <li>
-  <p>The OMERO Virtual Appliance allows you to try out an OMERO server on your local machine </p>
-  </li>
-  <li>
-    <p>Instructions for using the Virtual Appliance are at: <a href="@DOC_URL@/users/virtual-appliance.html">Virtual Appliance</a></p>
-  </li>
-</ul>
-
-
-<h2><a name="api" id="api"></a>OMERO API documentation</h2>
-<div class="alt-table">
-<table width="800" border="0" cellpadding="5">
-  <tbody>
-    <tr>
-      <th width="269">API Documentation</th>
-      <th width="92">Size</th>
-      <th width="271">File Name</th>
-      <th width="118">MD5 Checksum</th>
-    </tr>
-    <tr>
-      <td><a href="@DOCS@"><img src="images/api_download.png" alt="API Documentation Download" /></a></td>
-      <td align="center">@DOCS_SIZE@</td>
-      <td>@DOCS_BASE@</td>
-      <td align="center">@DOCS_MD5@ (<a href="@DOCS@.md5">MD5</a>)</td>
-      </tr>
-  </tbody>
-</table>
-</div>
-
-<ul>
-  <li>
-  <p>The OMERO API documentation is also available to read on the web <a href="api">here</a></p>
-  </li>
-  <li>
-  <p>Zipped files of API documentation for other versions of Ice are available as part of the <a href="#components">build components</a></p>
-  </li>
-</ul>
-
-<h2><a name="code" id="code"></a>Checking out the code</h2>
-
-<div class="alt-table">
-<table width="800" border="0" cellpadding="5">
-  <tbody>
-    <tr>
-      <th width="269">Source Code</th>
-      <th width="91">Size</th>
-      <th width="270">File Name</th>
-      <th width="120">Checksum</th>
-      </tr>
-    <tr>
-      <td><a href="@SOURCE_CODE@" target="_blank"><img src="images/ome_source_code.png" alt="Zipped Source Code" /></a></td>
-      <td align="center">@SOURCE_CODE_SIZE@</td>
-      <td>@SOURCE_CODE_BASE@</td>
-      <td align="center">@SOURCE_CODE_MD5@ (<a href="@SOURCE_CODE@.md5">MD5</a>)</td>
-      </tr>
-  </tbody>
-</table>
-</div>
-
-<div class="alt-table">
-<table width="278" border="0" cellpadding="5">
-  <tbody>
-    <tr>
-      <th width="264">Source Code Links</th>
-    </tr>
-    <tr>
-      <td><a href="http://github.com/openmicroscopy/openmicroscopy" target="_blank"><img src="images/github_rep_link.png" alt="GitHub Repository Link" /></a></td>
-    </tr>
-    <tr>
-      <td><a href="http://git.openmicroscopy.org/" target="_blank"><img src="images/gitweb_int_link.png" alt="Gitweb Interface Link" /></a></td>
-    </tr>
-    <tr>
-      <td><a href="@TAG_URL@" target="_blank"><img src="images/git_tag.png" alt="GitHub Tag" /></a></td>
-    </tr>
-  </tbody>
-</table>
-</div>
-<ul>
-  <li>
-<p>Instructions for installing the source code can be found at: <a href="@DOC_URL@/developers/installation.html" target="_blank">Installing OMERO from source</a></p>
-    </li>
-</ul>
-
-<h2><a name="components" id="components"></a><a name="artifacts" id="artifacts"></a>Download components</h2>
-
-<ul>
-  <li>
-<p>All components available for this version of OMERO are available <a href="artifacts">here</a></p>
-  </li>
-</ul>
-
-<h2><a name="previous" id="previous"></a>Previous versions</h2>
-
-<ul>
-  <li>
-<p>We recommend that you always use the most recent release version of the OMERO software, but if you need to use a previous version,  they are all available from the main <a href="http://downloads.openmicroscopy.org/omero/?C=M;O=D">downloads folder</a></p>
-  </li>
-</ul>
-
-  </div><!-- /.entry-content -->
-</section>
-        <footer id="contentinfo" class="body">
-        </footer><!-- /#contentinfo -->
-
-		<!-- OME Footer - Start -->
-		<div class="visualClear" id="clear-space-before-footer"><!-- --></div>
-		<div id="portal-footer">
-			<p>
-				<acronym title="Copyright">&copy;</acronym>
-				2000-2014
-				University of Dundee &amp; Open Microscopy Environment. <a href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing">Creative Commons Attribution 3.0 Unported License</a>
-			</p>
-			<p>
-				OME source code is available under the <a href="http://www.openmicroscopy.org/site/about/licensing">GNU General public license</a> or through commercial license from <a href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software">Glencoe Software</a>
-			</p>
+					<li>
+						<p>The functionality of the existing OMERO clients can be extended using
+							scripts, for details and scripts see: <a
+								href="http://www.openmicroscopy.org/site/community/scripts"
+								target="_blank">Script Sharing</a></p>
+					</li>
+				</ul>
+				<h2><a name="servers" id="servers"></a>OMERO server @VERSION@ downloads</h2>
+				<div class="alt-table">
+					<table width="800" border="0" cellpadding="5">
+						<tbody>
+							<tr>
+								<th width="269">Servers</th>
+								<th width="89">Size</th>
+								<th width="270">File Name</th>
+								<th width="122">Checksum</th>
+							</tr>
+							<tr>
+								<td><a href="@SERVER33@"><img src="images/ice3_3_download.png"
+											alt="Ice 3.3 Server Download" /></a></td>
+								<td align="center">@SERVER33_SIZE@</td>
+								<td>@SERVER33_BASE@</td>
+								<td align="center">@SERVER33_MD5@ (<a href="@SERVER33@.md5"
+									>MD5</a>)</td>
+							</tr>
+							<tr>
+								<td><a href="@SERVER34@"><img src="images/ice3_4_download.png"
+											alt="Ice 3.4 Server Download" /></a></td>
+								<td align="center">@SERVER34_SIZE@</td>
+								<td>@SERVER34_BASE@</td>
+								<td align="center">@SERVER34_MD5@ (<a href="@SERVER34@.md5"
+									>MD5</a>)</td>
+							</tr>
+							<tr>
+								<td><a href="@SERVER35@"><img src="images/ice3_5_download_linux.png"
+											alt="Ice 3.5 Server Download" /></a></td>
+								<td align="center">@SERVER35_SIZE@</td>
+								<td>@SERVER35_BASE@</td>
+								<td align="center">@SERVER35_MD5@ (<a href="@SERVER35@.md5"
+									>MD5</a>)</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<ul>
+					<li>
+						<p>If you are using Windows, we recommend you default to using OMERO.server
+							with Ice 3.4. The Ice 3.5 server is not supported on Windows because Ice
+							3.5 requires Python 3, which OMERO does not yet support (see the <a
+								href="@DOC_URL@/sysadmins/limitations.html#windows-os-issues">Known
+								Limitations</a> page for more detail)</p>
+					</li>
+					<li>
+						<p>Download the server matching the Ice version you are using (note that the
+							client(s) should work with any version of the server)</p>
+					</li>
+					<li>
+						<p>Installation instructions are available for: <a
+								href="@DOC_URL@/sysadmins/unix/server-installation.html">Unix
+								platforms</a>, <a
+								href="@DOC_URL@/sysadmins/windows/server-installation.html"
+								>Microsoft Windows</a>
+						</p>
+					</li>
+					<li>
+						<p>Server upgrade instructions are at: <a
+								href="@DOC_URL@/sysadmins/server-upgrade.html">OMERO.server
+								upgrade</a></p>
+					</li>
+				</ul>
+				<h2><a name="va" id="va"></a>OMERO Virtual Appliance download</h2>
+				<div class="alt-table">
+					<table width="800" border="0" cellpadding="5">
+						<tbody>
+							<tr>
+								<th width="269">Virtual Appliance</th>
+								<th width="91">Size</th>
+								<th width="270">File Name</th>
+								<th width="120">Checksum</th>
+							</tr>
+							<tr>
+								<td><a href="@VM@"><img src="images/virtual_app_download.png"
+											alt="Virtual Appliance Download" /></a></td>
+								<td align="center">@VM_SIZE@</td>
+								<td>@VM_BASE@</td>
+								<td align="center">@VM_MD5@ (<a href="@VM@.md5">MD5</a>)</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<ul>
+					<li>
+						<p>The OMERO Virtual Appliance allows you to try out an OMERO server on your
+							local machine </p>
+					</li>
+					<li>
+						<p>Instructions for using the Virtual Appliance are at: <a
+								href="@DOC_URL@/users/virtual-appliance.html">Virtual
+							Appliance</a></p>
+					</li>
+				</ul>
+				<h2><a name="api" id="api"></a>OMERO API documentation</h2>
+				<div class="alt-table">
+					<table width="800" border="0" cellpadding="5">
+						<tbody>
+							<tr>
+								<th width="269">API Documentation</th>
+								<th width="92">Size</th>
+								<th width="271">File Name</th>
+								<th width="118">MD5 Checksum</th>
+							</tr>
+							<tr>
+								<td><a href="@DOCS@"><img src="images/api_download.png"
+											alt="API Documentation Download" /></a></td>
+								<td align="center">@DOCS_SIZE@</td>
+								<td>@DOCS_BASE@</td>
+								<td align="center">@DOCS_MD5@ (<a href="@DOCS@.md5">MD5</a>)</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<ul>
+					<li>
+						<p>The OMERO API documentation is also available to read on the web <a
+								href="api">here</a></p>
+					</li>
+					<li>
+						<p>Zipped files of API documentation for other versions of Ice are available
+							as part of the <a href="#components">build components</a></p>
+					</li>
+				</ul>
+				<h2><a name="code" id="code"></a>Checking out the code</h2>
+				<div class="alt-table">
+					<table width="800" border="0" cellpadding="5">
+						<tbody>
+							<tr>
+								<th width="269">Source Code</th>
+								<th width="91">Size</th>
+								<th width="270">File Name</th>
+								<th width="120">Checksum</th>
+							</tr>
+							<tr>
+								<td><a href="@SOURCE_CODE@" target="_blank"><img
+											src="images/ome_source_code.png"
+											alt="Zipped Source Code" /></a></td>
+								<td align="center">@SOURCE_CODE_SIZE@</td>
+								<td>@SOURCE_CODE_BASE@</td>
+								<td align="center">@SOURCE_CODE_MD5@ (<a href="@SOURCE_CODE@.md5"
+										>MD5</a>)</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<div class="alt-table">
+					<table width="278" border="0" cellpadding="5">
+						<tbody>
+							<tr>
+								<th width="264">Source Code Links</th>
+							</tr>
+							<tr>
+								<td><a href="http://github.com/openmicroscopy/openmicroscopy"
+										target="_blank"><img src="images/github_rep_link.png"
+											alt="GitHub Repository Link" /></a></td>
+							</tr>
+							<tr>
+								<td><a href="http://git.openmicroscopy.org/" target="_blank"><img
+											src="images/gitweb_int_link.png"
+											alt="Gitweb Interface Link" /></a></td>
+							</tr>
+							<tr>
+								<td><a href="@TAG_URL@" target="_blank"><img
+											src="images/git_tag.png" alt="GitHub Tag" /></a></td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<ul>
+					<li>
+						<p>Instructions for installing the source code can be found at: <a
+								href="@DOC_URL@/developers/installation.html" target="_blank"
+								>Installing OMERO from source</a></p>
+					</li>
+				</ul>
+				<h2><a name="components" id="components"></a><a name="artifacts" id="artifacts"
+					></a>Download components</h2>
+				<ul>
+					<li>
+						<p>All components available for this version of OMERO are available <a
+								href="artifacts">here</a></p>
+					</li>
+				</ul>
+				<h2><a name="previous" id="previous"></a>Previous versions</h2>
+				<ul>
+					<li>
+						<p>We recommend that you always use the most recent release version of the
+							OMERO software, but if you need to use a previous version, they are all
+							available from the main <a
+								href="http://downloads.openmicroscopy.org/omero/?C=M;O=D">downloads
+								folder</a></p>
+					</li>
+				</ul>
+			</div><!-- /.entry-content -->
+			<!-- </section>  -->
+			<!-- <footer id="contentinfo" class="body">
+			</footer> --><!-- /#contentinfo -->
+			<!-- OME Footer - Start -->
+			<div class="visualClear" id="clear-space-before-footer"><!-- --></div>
+			<div id="portal-footer">
+				<p>
+					<acronym title="Copyright">&copy;</acronym> 2000-2014 University of Dundee &amp;
+					Open Microscopy Environment. <a
+						href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
+						>Creative Commons Attribution 3.0 Unported License</a>
+				</p>
+				<p> OME source code is available under the <a
+						href="http://www.openmicroscopy.org/site/about/licensing">GNU General public
+						license</a> or through commercial license from <a
+						href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software"
+						>Glencoe Software</a>
+				</p>
+			</div>
+			<div class="visualClear">
+				<!-- OME Footer - END -->
+			</div>
 		</div>
-		<div class="visualClear">
-		<!-- OME Footer - END -->
-
-</div></div></body></html>
+	</body>
+</html>

--- a/searcher_downloads.html
+++ b/searcher_downloads.html
@@ -1,142 +1,151 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
-	<head>
-		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 
-		<link rel="stylesheet" href="images/plonematch.css" type="text/css" />
+        <link rel="stylesheet" href="images/plonematch.css" type="text/css" />
 
-		<style type="text/css">
-			[touch-action = "none"]{
-				-ms-touch-action:none;
-				touch-action:none;
-			}
-			[touch-action = "pan-x"]{
-				-ms-touch-action:pan-x;
-				touch-action:pan-x;
-			}
-			[touch-action = "pan-y"]{
-				-ms-touch-action:pan-y;
-				touch-action:pan-y;
-			}
-			[touch-action = "scroll"],
-			[touch-action = "pan-x pan-y"],
-			[touch-action = "pan-y pan-x"]{
-				-ms-touch-action:pan-x pan-y;
-				touch-action:pan-x pan-y;
-			}</style>
-		<title></title>
-	</head>
-	<body id="index" class="home">
-		<!-- OME Banner - START -->
-		<div id="portal-top">
-			<div id="portal-header">
-				<ul id="portal-siteactions">
-					<li>
-						<br />
-					</li>
-				</ul><a id="portal-logo" accesskey="1" href="http://downloads.openmicroscopy.org/"
-					name="portal-logo"><img src="images/logo.jpg" alt="" title="" height="73"
-						width="450" /></a>
-				<div id="portal-globalnav">
-					<br />
-				</div>
-			</div>
-			<div id="portal-personaltools-wrapper">
-				<ul id="portal-personaltools" class="visualInline">
-					<li>
-						<br />
-					</li>
-				</ul>
-			</div>
-		</div>
-		<div class="visualClear" id="clear-space-before-wrapper-table">
-			<!-- OME Banner - END -->
-			<!-- /#menu -->
-			<!-- <section id="content" class="body" style="margin-left:20px;">  -->
-			<div class="entry-content">
-				<h2>OMERO.searcher @VERSION@</h2>
-				<ul>
-					<li>
-						<p>OMERO.searcher provides the ability to search for images in OMERO by
-							their content rather than just by their annotations. At present it is
-							not recommended for production use.</p>
-					</li>
+        <style type="text/css">
+            [touch-action = "none"]{
+                -ms-touch-action:none;
+                touch-action:none;
+            }
+            [touch-action = "pan-x"]{
+                -ms-touch-action:pan-x;
+                touch-action:pan-x;
+            }
+            [touch-action = "pan-y"]{
+                -ms-touch-action:pan-y;
+                touch-action:pan-y;
+            }
+            [touch-action = "scroll"],
+            [touch-action = "pan-x pan-y"],
+            [touch-action = "pan-y pan-x"]{
+                -ms-touch-action:pan-x pan-y;
+                touch-action:pan-x pan-y;
+            }</style>
+        <title></title>
+    </head>
+    <body id="index" class="home">
+        <!-- OME Banner - START -->
+        <div id="portal-top">
+            <div id="portal-header">
+                <ul id="portal-siteactions">
+                    <li>
+                        <br />
+                    </li>
+                </ul><a id="portal-logo" accesskey="1"
+                    href="http://downloads.openmicroscopy.org/"
+                    name="portal-logo"><img src="images/logo.jpg" alt=""
+                        title="" height="73" width="450" /></a>
+                <div id="portal-globalnav">
+                    <br />
+                </div>
+            </div>
+            <div id="portal-personaltools-wrapper">
+                <ul id="portal-personaltools" class="visualInline">
+                    <li>
+                        <br />
+                    </li>
+                </ul>
+            </div>
+        </div>
+        <div class="visualClear" id="clear-space-before-wrapper-table">
+            <!-- OME Banner - END -->
+            <!-- /#menu -->
+            <!-- <section id="content" class="body" style="margin-left:20px;">  -->
+            <div class="entry-content">
+                <h2>OMERO.searcher @VERSION@</h2>
+                <ul>
+                    <li>
+                        <p>OMERO.searcher provides the ability to search for
+                            images in OMERO by their content rather than just by
+                            their annotations. At present it is not recommended
+                            for production use.</p>
+                    </li>
 
-					<li>
-						<p>More information can be found on the <a
-								href="http://www.openmicroscopy.org/site/products/partner/omero.searcher"
-								>Open Microscopy Partners Page</a>, and on the <a
-								href="http://murphylab.web.cmu.edu/software/searcher/">Murphy Lab
-								software page</a>.</p>
-					</li>
+                    <li>
+                        <p>More information can be found on the <a
+                                href="http://www.openmicroscopy.org/site/products/partner/omero.searcher"
+                                >Open Microscopy Partners Page</a>, and on the
+                                <a
+                                href="http://murphylab.web.cmu.edu/software/searcher/"
+                                >Murphy Lab software page</a>.</p>
+                    </li>
 
-					<li>
-						<p>Source code and the latest development version can always be found on <a
-								href="https://github.com/openmicroscopy/omero_searcher"
-							>GitHub</a>.</p>
-					</li>
-				</ul>
-				<h2>Downloads</h2>
-				<div class="alt-table">
-					<table width="800" border="0" cellpadding="5">
-						<tbody>
-							<tr>
-								<th width="269">File</th>
-								<th width="85">Size</th>
-								<th width="271">File Name</th>
-								<th width="125">Checksum</th>
-							</tr>
-							<tr>
-								<td><a href="@SEARCHER@"><img
-											src="images/searcher/omero_searcher.png"
-											alt="OMERO.searcher download" /></a></td>
-								<td align="center">@SEARCHER_SIZE@</td>
-								<td>@SEARCHER_BASE@</td>
-								<td align="center">@SEARCHER_MD5@ (<a href="@SEARCHER@.md5"
-									>MD5</a>)</td>
-							</tr>
-							<tr>
-								<td><a href="@PYSLID@"><img src="images/searcher/pyslid.png"
-											alt="pyslid download" /></a></td>
-								<td align="center">@PYSLID_SIZE@</td>
-								<td>@PYSLID_BASE@</td>
-								<td align="center">@PYSLID_MD5@ (<a href="@PYSLID@.md5"
-									>MD5</a>)</td>
-							</tr>
-							<tr>
-								<td><a href="@RICERCA@"><img src="images/searcher/ricerca.png"
-											alt="ricerca download" /></a></td>
-								<td align="center">@RICERCA_SIZE@</td>
-								<td>@RICERCA_BASE@</td>
-								<td align="center">@RICERCA_MD5@ (<a href="@RICERCA@.md5"
-									>MD5</a>)</td>
-							</tr>
-						</tbody>
-					</table>
-				</div>
-			</div><!-- /.entry-content -->
-			<!-- </section>  -->
-			<!-- <footer id="contentinfo" class="body">
+                    <li>
+                        <p>Source code and the latest development version can
+                            always be found on <a
+                                href="https://github.com/openmicroscopy/omero_searcher"
+                                >GitHub</a>.</p>
+                    </li>
+                </ul>
+                <h2>Downloads</h2>
+                <div class="alt-table">
+                    <table width="800" border="0" cellpadding="5">
+                        <tbody>
+                            <tr>
+                                <th width="269">File</th>
+                                <th width="85">Size</th>
+                                <th width="271">File Name</th>
+                                <th width="125">Checksum</th>
+                            </tr>
+                            <tr>
+                                <td><a href="@SEARCHER@"><img
+                                        src="images/searcher/omero_searcher.png"
+                                        alt="OMERO.searcher download"
+                                     /></a></td>
+                                <td align="center">@SEARCHER_SIZE@</td>
+                                <td>@SEARCHER_BASE@</td>
+                                <td align="center">@SEARCHER_MD5@ (<a
+                                        href="@SEARCHER@.md5">MD5</a>)</td>
+                            </tr>
+                            <tr>
+                                <td><a href="@PYSLID@"><img
+                                        src="images/searcher/pyslid.png"
+                                        alt="pyslid download" /></a></td>
+                                <td align="center">@PYSLID_SIZE@</td>
+                                <td>@PYSLID_BASE@</td>
+                                <td align="center">@PYSLID_MD5@ (<a
+                                        href="@PYSLID@.md5">MD5</a>)</td>
+                            </tr>
+                            <tr>
+                                <td><a href="@RICERCA@"><img
+                                        src="images/searcher/ricerca.png"
+                                        alt="ricerca download" /></a></td>
+                                <td align="center">@RICERCA_SIZE@</td>
+                                <td>@RICERCA_BASE@</td>
+                                <td align="center">@RICERCA_MD5@ (<a
+                                        href="@RICERCA@.md5">MD5</a>)</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div><!-- /.entry-content -->
+            <!-- </section>  -->
+            <!-- <footer id="contentinfo" class="body">
 			</footer> --><!-- /#contentinfo -->
-			<!-- OME Footer - Start -->
-			<div class="visualClear" id="clear-space-before-footer"><!-- --></div>
-			<div id="portal-footer">
-				<p>
-					<acronym title="Copyright">&copy;</acronym> 2000-2014 University of Dundee &amp;
-					Open Microscopy Environment. <a
-						href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
-						>Creative Commons Attribution 3.0 Unported License</a>
-				</p>
-				<p> OME source code is available under the <a
-						href="http://www.openmicroscopy.org/site/about/licensing">GNU General public
-						license</a> or through commercial license from <a
-						href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software"
-						>Glencoe Software</a>
-				</p>
-			</div>
-			<div class="visualClear">
-				<!-- OME Footer - END -->
-			</div>
-		</div>
-	</body>
+            <!-- OME Footer - Start -->
+            <div class="visualClear" id="clear-space-before-footer"
+                ><!-- --></div>
+            <div id="portal-footer">
+                <p>
+                    <acronym title="Copyright">&copy;</acronym> 2000-2014
+                    University of Dundee &amp; Open Microscopy Environment. <a
+                        href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
+                        >Creative Commons Attribution 3.0 Unported License</a>
+                </p>
+                <p> OME source code is available under the <a
+                        href="http://www.openmicroscopy.org/site/about/licensing"
+                        >GNU General public license</a> or through commercial
+                    license from <a
+                        href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software"
+                        >Glencoe Software</a>
+                </p>
+            </div>
+            <div class="visualClear">
+                <!-- OME Footer - END -->
+            </div>
+        </div>
+    </body>
 </html>

--- a/searcher_downloads.html
+++ b/searcher_downloads.html
@@ -52,9 +52,7 @@
         </div>
         <div class="visualClear" id="clear-space-before-wrapper-table">
             <!-- OME Banner - END -->
-            <!-- /#menu -->
-            <!-- <section id="content" class="body" style="margin-left:20px;">  -->
-            <div class="entry-content">
+        	<div class="entry-content" style="margin-left:20px;">
                 <h2>OMERO.searcher @VERSION@</h2>
                 <ul>
                     <li>
@@ -122,10 +120,8 @@
                     </table>
                 </div>
             </div><!-- /.entry-content -->
-            <!-- </section>  -->
-            <!-- <footer id="contentinfo" class="body">
-			</footer> --><!-- /#contentinfo -->
-            <!-- OME Footer - Start -->
+
+        	<!-- OME Footer - Start -->
             <div class="visualClear" id="clear-space-before-footer"
                 ><!-- --></div>
             <div id="portal-footer">

--- a/searcher_downloads.html
+++ b/searcher_downloads.html
@@ -82,7 +82,7 @@
                 </ul>
                 <h2>Downloads</h2>
                 <div class="alt-table">
-                    <table width="800" border="0" cellpadding="5">
+                    <table width="800" border="0" cellpadding="5" summary="Downloads">
                         <tbody>
                             <tr>
                                 <th width="269">File</th>

--- a/searcher_downloads.html
+++ b/searcher_downloads.html
@@ -1,110 +1,142 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 
-    <link rel="stylesheet" href="images/plonematch.css" type="text/css">
-    <meta charset="utf-8">
+		<link rel="stylesheet" href="images/plonematch.css" type="text/css" />
 
-
-    <meta name="tags" contents="OMERO.searcher">
-  
-    <style type="text/css"></style><style>[touch-action="none"]{ -ms-touch-action: none; touch-action: none; }[touch-action="pan-x"]{ -ms-touch-action: pan-x; touch-action: pan-x; }[touch-action="pan-y"]{ -ms-touch-action: pan-y; touch-action: pan-y; }[touch-action="scroll"],[touch-action="pan-x pan-y"],[touch-action="pan-y pan-x"]{ -ms-touch-action: pan-x pan-y; touch-action: pan-x pan-y; }</style></head>
-    <body id="index" class="home">
-
+		<style type="text/css">
+			[touch-action = "none"]{
+				-ms-touch-action:none;
+				touch-action:none;
+			}
+			[touch-action = "pan-x"]{
+				-ms-touch-action:pan-x;
+				touch-action:pan-x;
+			}
+			[touch-action = "pan-y"]{
+				-ms-touch-action:pan-y;
+				touch-action:pan-y;
+			}
+			[touch-action = "scroll"],
+			[touch-action = "pan-x pan-y"],
+			[touch-action = "pan-y pan-x"]{
+				-ms-touch-action:pan-x pan-y;
+				touch-action:pan-x pan-y;
+			}</style>
+		<title></title>
+	</head>
+	<body id="index" class="home">
 		<!-- OME Banner - START -->
 		<div id="portal-top">
 			<div id="portal-header">
 				<ul id="portal-siteactions">
 					<li>
-						<br>
+						<br />
 					</li>
-				</ul><a id="portal-logo" accesskey="1" href="http://downloads.openmicroscopy.org/" name="portal-logo"><img src="images/logo.jpg" alt="" title="" height="73" width="450"></a>
-			  <div id="portal-globalnav">
-					<br>
+				</ul><a id="portal-logo" accesskey="1" href="http://downloads.openmicroscopy.org/"
+					name="portal-logo"><img src="images/logo.jpg" alt="" title="" height="73"
+						width="450" /></a>
+				<div id="portal-globalnav">
+					<br />
 				</div>
 			</div>
 			<div id="portal-personaltools-wrapper">
 				<ul id="portal-personaltools" class="visualInline">
 					<li>
-						<br>
+						<br />
 					</li>
 				</ul>
 			</div>
 		</div>
 		<div class="visualClear" id="clear-space-before-wrapper-table">
-		<!-- OME Banner - END -->
+			<!-- OME Banner - END -->
+			<!-- /#menu -->
+			<!-- <section id="content" class="body" style="margin-left:20px;">  -->
+			<div class="entry-content">
+				<h2>OMERO.searcher @VERSION@</h2>
+				<ul>
+					<li>
+						<p>OMERO.searcher provides the ability to search for images in OMERO by
+							their content rather than just by their annotations. At present it is
+							not recommended for production use.</p>
+					</li>
 
-                                  <!-- /#menu -->
-<section id="content" class="body" style="margin-left:20px;">
+					<li>
+						<p>More information can be found on the <a
+								href="http://www.openmicroscopy.org/site/products/partner/omero.searcher"
+								>Open Microscopy Partners Page</a>, and on the <a
+								href="http://murphylab.web.cmu.edu/software/searcher/">Murphy Lab
+								software page</a>.</p>
+					</li>
 
-<div class="entry-content">
-
-<h2>OMERO.searcher @VERSION@</h2>
-
-<ul>
-<li>
-<p>OMERO.searcher provides the ability to search for images in OMERO by their content rather than just by their annotations. At present it is not recommended for production use.</p>
-</li>
-
-<li>
-<p>More information can be found on the <a href="http://www.openmicroscopy.org/site/products/partner/omero.searcher">Open Microscopy Partners Page</a>, and on the <a href="http://murphylab.web.cmu.edu/software/searcher/">Murphy Lab software page</a>.</p>
-</li>
-
-<li>
-<p>Source code and the latest development version can always be found on <a href="https://github.com/openmicroscopy/omero_searcher">GitHub</a>.</p>
-</li>
-</ul>
-
-<h2>Downloads</h2>
-
-<div class="alt-table">
-  <table width="800" border="0" cellpadding="5">
-    <tbody>
-      <tr>
-        <th width="269">File</th>
-        <th width="85">Size</th>
-        <th width="271">File Name</th>
-        <th width="125">Checksum</th>
-        </tr>
-      <tr>
-        <td><a href="@SEARCHER@"><img src="images/searcher/omero_searcher.png" alt="OMERO.searcher download" /></a></td>
-        <td align="center">@SEARCHER_SIZE@</td>
-        <td>@SEARCHER_BASE@</td>
-        <td align="center">@SEARCHER_MD5@ (<a href="@SEARCHER@.md5">MD5</a>)</td>
-      </tr>
-      <tr>
-        <td><a href="@PYSLID@"><img src="images/searcher/pyslid.png" alt="pyslid download" /></a></td>
-        <td align="center">@PYSLID_SIZE@</td>
-        <td>@PYSLID_BASE@</td>
-        <td align="center">@PYSLID_MD5@ (<a href="@PYSLID@.md5">MD5</a>)</td>
-      </tr>
-      <tr>
-        <td><a href="@RICERCA@"><img src="images/searcher/ricerca.png" alt="ricerca download" /></a></td>
-        <td align="center">@RICERCA_SIZE@</td>
-        <td>@RICERCA_BASE@</td>
-        <td align="center">@RICERCA_MD5@ (<a href="@RICERCA@.md5">MD5</a>)</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-  
-  </div><!-- /.entry-content -->
-</section>
-        <footer id="contentinfo" class="body">
-        </footer><!-- /#contentinfo -->
-
-		<!-- OME Footer - Start -->
-		<div class="visualClear" id="clear-space-before-footer"><!-- --></div>
-		<div id="portal-footer">
-			<p>
-				<acronym title="Copyright">&copy;</acronym>
-				2000-2014
-				University of Dundee &amp; Open Microscopy Environment. <a href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing">Creative Commons Attribution 3.0 Unported License</a>
-			</p>
-			<p>
-				OME source code is available under the <a href="http://www.openmicroscopy.org/site/about/licensing">GNU General public license</a> or through commercial license from <a href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software">Glencoe Software</a>
-			</p>
+					<li>
+						<p>Source code and the latest development version can always be found on <a
+								href="https://github.com/openmicroscopy/omero_searcher"
+							>GitHub</a>.</p>
+					</li>
+				</ul>
+				<h2>Downloads</h2>
+				<div class="alt-table">
+					<table width="800" border="0" cellpadding="5">
+						<tbody>
+							<tr>
+								<th width="269">File</th>
+								<th width="85">Size</th>
+								<th width="271">File Name</th>
+								<th width="125">Checksum</th>
+							</tr>
+							<tr>
+								<td><a href="@SEARCHER@"><img
+											src="images/searcher/omero_searcher.png"
+											alt="OMERO.searcher download" /></a></td>
+								<td align="center">@SEARCHER_SIZE@</td>
+								<td>@SEARCHER_BASE@</td>
+								<td align="center">@SEARCHER_MD5@ (<a href="@SEARCHER@.md5"
+									>MD5</a>)</td>
+							</tr>
+							<tr>
+								<td><a href="@PYSLID@"><img src="images/searcher/pyslid.png"
+											alt="pyslid download" /></a></td>
+								<td align="center">@PYSLID_SIZE@</td>
+								<td>@PYSLID_BASE@</td>
+								<td align="center">@PYSLID_MD5@ (<a href="@PYSLID@.md5"
+									>MD5</a>)</td>
+							</tr>
+							<tr>
+								<td><a href="@RICERCA@"><img src="images/searcher/ricerca.png"
+											alt="ricerca download" /></a></td>
+								<td align="center">@RICERCA_SIZE@</td>
+								<td>@RICERCA_BASE@</td>
+								<td align="center">@RICERCA_MD5@ (<a href="@RICERCA@.md5"
+									>MD5</a>)</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+			</div><!-- /.entry-content -->
+			<!-- </section>  -->
+			<!-- <footer id="contentinfo" class="body">
+			</footer> --><!-- /#contentinfo -->
+			<!-- OME Footer - Start -->
+			<div class="visualClear" id="clear-space-before-footer"><!-- --></div>
+			<div id="portal-footer">
+				<p>
+					<acronym title="Copyright">&copy;</acronym> 2000-2014 University of Dundee &amp;
+					Open Microscopy Environment. <a
+						href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
+						>Creative Commons Attribution 3.0 Unported License</a>
+				</p>
+				<p> OME source code is available under the <a
+						href="http://www.openmicroscopy.org/site/about/licensing">GNU General public
+						license</a> or through commercial license from <a
+						href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software"
+						>Glencoe Software</a>
+				</p>
+			</div>
+			<div class="visualClear">
+				<!-- OME Footer - END -->
+			</div>
 		</div>
-		<div class="visualClear">
-		<!-- OME Footer - END -->
-	
-</div></div></body></html>
+	</body>
+</html>

--- a/utrack_downloads.html
+++ b/utrack_downloads.html
@@ -65,7 +65,7 @@
                 </ul>
                 <h2><a name="code" id="code"></a>Downloads</h2>
                 <div class="alt-table">
-                    <table width="800" border="0" cellpadding="5">
+                    <table width="800" border="0" cellpadding="5" summary="Downloads">
                         <tbody>
                             <tr>
                                 <th width="269">Source Code</th>

--- a/utrack_downloads.html
+++ b/utrack_downloads.html
@@ -1,135 +1,144 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
-	<head>
-		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 
-		<link rel="stylesheet" href="images/plonematch.css" type="text/css" />
-		<style type="text/css">
-			[touch-action = "none"]{
-				-ms-touch-action:none;
-				touch-action:none;
-			}
-			[touch-action = "pan-x"]{
-				-ms-touch-action:pan-x;
-				touch-action:pan-x;
-			}
-			[touch-action = "pan-y"]{
-				-ms-touch-action:pan-y;
-				touch-action:pan-y;
-			}
-			[touch-action = "scroll"],
-			[touch-action = "pan-x pan-y"],
-			[touch-action = "pan-y pan-x"]{
-				-ms-touch-action:pan-x pan-y;
-				touch-action:pan-x pan-y;
-			}</style>
-		<title></title>
-	</head>
-	<body id="index" class="home">
-		<!-- OME Banner - START -->
-		<div id="portal-top">
-			<div id="portal-header">
-				<ul id="portal-siteactions">
-					<li>
-						<br />
-					</li>
-				</ul><a id="portal-logo" accesskey="1" href="http://downloads.openmicroscopy.org/"
-					name="portal-logo"><img src="images/logo.jpg" alt="" title="" height="73"
-						width="450" /></a>
-				<div id="portal-globalnav">
-					<br />
-				</div>
-			</div>
-			<div id="portal-personaltools-wrapper">
-				<ul id="portal-personaltools" class="visualInline">
-					<li>
-						<br />
-					</li>
-				</ul>
-			</div>
-		</div>
-		<div class="visualClear" id="clear-space-before-wrapper-table">
-			<!-- OME Banner - END -->
-			<!-- /#menu -->
-			<!-- <section id="content" class="body" style="margin-left:20px;"> -->
-			<div class="entry-content">
-				<h2>u-track @VERSION@ Downloads</h2>
-				<ul>
-					<li>
-						<p>The software is currently distributed as a source code bundle and
-							requires MATLAB to be installed with some toolboxes described in the <a
-								href="@DOC@">PDF documentation</a>.</p>
-					</li>
-				</ul>
-				<h2><a name="code" id="code"></a>Downloads</h2>
-				<div class="alt-table">
-					<table width="800" border="0" cellpadding="5">
-						<tbody>
-							<tr>
-								<th width="269">Source Code</th>
-								<th width="91">Size</th>
-								<th width="270">File Name</th>
-								<th width="120">Checksum</th>
-							</tr>
-							<tr>
-								<td><a href="@SOURCE_CODE@" target="_blank"><img
-											src="images/utrack.png" alt="Zipped Source Code"
-									 /></a></td>
-								<td align="center">@SOURCE_CODE_SIZE@</td>
-								<td>@SOURCE_CODE_BASE@</td>
-								<td align="center">@SOURCE_CODE_MD5@ (<a href="@SOURCE_CODE@.md5"
-										>MD5</a>)</td>
-							</tr>
-						</tbody>
-					</table>
-				</div>
-				<ul>
-					<li>
-						<p>To use u-track with OMERO, you will need to download the OMERO.matlab
-							toolbox for the same OMERO release number as your server from the <a
-								href="http://downloads.openmicroscopy.org/omero">OMERO downloads
-								folders</a> in addition to the zipped code.</p>
-					</li>
-					<li>
-						<p>To get started, download the zipped code, unextract it and add it with
-							its subfolders to your MATLAB path. Then launch the software by entering
-								<code>movieSelectorGUI</code> at the MATLAB command prompt.</p>
-					</li>
+        <link rel="stylesheet" href="images/plonematch.css" type="text/css" />
+        <style type="text/css">
+            [touch-action = "none"]{
+                -ms-touch-action:none;
+                touch-action:none;
+            }
+            [touch-action = "pan-x"]{
+                -ms-touch-action:pan-x;
+                touch-action:pan-x;
+            }
+            [touch-action = "pan-y"]{
+                -ms-touch-action:pan-y;
+                touch-action:pan-y;
+            }
+            [touch-action = "scroll"],
+            [touch-action = "pan-x pan-y"],
+            [touch-action = "pan-y pan-x"]{
+                -ms-touch-action:pan-x pan-y;
+                touch-action:pan-x pan-y;
+            }</style>
+        <title></title>
+    </head>
+    <body id="index" class="home">
+        <!-- OME Banner - START -->
+        <div id="portal-top">
+            <div id="portal-header">
+                <ul id="portal-siteactions">
+                    <li>
+                        <br />
+                    </li>
+                </ul><a id="portal-logo" accesskey="1"
+                    href="http://downloads.openmicroscopy.org/"
+                    name="portal-logo"><img src="images/logo.jpg" alt=""
+                        title="" height="73" width="450" /></a>
+                <div id="portal-globalnav">
+                    <br />
+                </div>
+            </div>
+            <div id="portal-personaltools-wrapper">
+                <ul id="portal-personaltools" class="visualInline">
+                    <li>
+                        <br />
+                    </li>
+                </ul>
+            </div>
+        </div>
+        <div class="visualClear" id="clear-space-before-wrapper-table">
+            <!-- OME Banner - END -->
+            <!-- /#menu -->
+            <!-- <section id="content" class="body" style="margin-left:20px;"> -->
+            <div class="entry-content">
+                <h2>u-track @VERSION@ Downloads</h2>
+                <ul>
+                    <li>
+                        <p>The software is currently distributed as a source
+                            code bundle and requires MATLAB to be installed with
+                            some toolboxes described in the <a href="@DOC@">PDF
+                                documentation</a>.</p>
+                    </li>
+                </ul>
+                <h2><a name="code" id="code"></a>Downloads</h2>
+                <div class="alt-table">
+                    <table width="800" border="0" cellpadding="5">
+                        <tbody>
+                            <tr>
+                                <th width="269">Source Code</th>
+                                <th width="91">Size</th>
+                                <th width="270">File Name</th>
+                                <th width="120">Checksum</th>
+                            </tr>
+                            <tr>
+                                <td><a href="@SOURCE_CODE@" target="_blank"><img
+                                        src="images/utrack.png"
+                                        alt="Zipped Source Code" /></a></td>
+                                <td align="center">@SOURCE_CODE_SIZE@</td>
+                                <td>@SOURCE_CODE_BASE@</td>
+                                <td align="center">@SOURCE_CODE_MD5@ (<a
+                                        href="@SOURCE_CODE@.md5">MD5</a>)</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <ul>
+                    <li>
+                        <p>To use u-track with OMERO, you will need to download
+                            the OMERO.matlab toolbox for the same OMERO release
+                            number as your server from the <a
+                                href="http://downloads.openmicroscopy.org/omero"
+                                >OMERO downloads folders</a> in addition to the
+                            zipped code.</p>
+                    </li>
+                    <li>
+                        <p>To get started, download the zipped code, unextract
+                            it and add it with its subfolders to your MATLAB
+                            path. Then launch the software by entering
+                                <code>movieSelectorGUI</code> at the MATLAB
+                            command prompt.</p>
+                    </li>
 
-				</ul>
-				<h2><a name="legacy" id="legacy"></a>Previous versions</h2>
-				<ul>
-					<li>
-						<p>We recommend that you always use the most recent release version of the
-							u-track software, but if you need to use a previous version, they are
-							all available from the main <a
-								href="http://downloads.openmicroscopy.org/u-track/?C=M;O=D"
-								>downloads folder</a>.</p>
-					</li>
-				</ul>
-			</div><!-- /.entry-content -->
-			<!-- </section> -->
-			<!-- <footer id="contentinfo" class="body">
+                </ul>
+                <h2><a name="legacy" id="legacy"></a>Previous versions</h2>
+                <ul>
+                    <li>
+                        <p>We recommend that you always use the most recent
+                            release version of the u-track software, but if you
+                            need to use a previous version, they are all
+                            available from the main <a
+                                href="http://downloads.openmicroscopy.org/u-track/?C=M;O=D"
+                                >downloads folder</a>.</p>
+                    </li>
+                </ul>
+            </div><!-- /.entry-content -->
+            <!-- </section> -->
+            <!-- <footer id="contentinfo" class="body">
 			</footer> --><!-- /#contentinfo -->
-			<!-- OME Footer - Start -->
-			<div class="visualClear" id="clear-space-before-footer"><!-- --></div>
-			<div id="portal-footer">
-				<p>
-					<acronym title="Copyright">&copy;</acronym> 2000-2014 University of Dundee &amp;
-					Open Microscopy Environment. <a
-						href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
-						>Creative Commons Attribution 3.0 Unported License</a>
-				</p>
-				<p> OME source code is available under the <a
-						href="http://www.openmicroscopy.org/site/about/licensing">GNU General public
-						license</a> or through commercial license from <a
-						href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software"
-						>Glencoe Software</a>
-				</p>
-			</div>
-			<div class="visualClear">
-				<!-- OME Footer - END -->
-			</div>
-		</div>
-	</body>
+            <!-- OME Footer - Start -->
+            <div class="visualClear" id="clear-space-before-footer"
+                ><!-- --></div>
+            <div id="portal-footer">
+                <p>
+                    <acronym title="Copyright">&copy;</acronym> 2000-2014
+                    University of Dundee &amp; Open Microscopy Environment. <a
+                        href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
+                        >Creative Commons Attribution 3.0 Unported License</a>
+                </p>
+                <p> OME source code is available under the <a
+                        href="http://www.openmicroscopy.org/site/about/licensing"
+                        >GNU General public license</a> or through commercial
+                    license from <a
+                        href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software"
+                        >Glencoe Software</a>
+                </p>
+            </div>
+            <div class="visualClear">
+                <!-- OME Footer - END -->
+            </div>
+        </div>
+    </body>
 </html>

--- a/utrack_downloads.html
+++ b/utrack_downloads.html
@@ -1,108 +1,135 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-        
-        <link rel="stylesheet" href="images/plonematch.css" type="text/css">
-        <meta charset="utf-8">
-          
-  
-      <meta name="tags" contents="flimfit">
-  
-    <style type="text/css"></style><style>[touch-action="none"]{ -ms-touch-action: none; touch-action: none; }[touch-action="pan-x"]{ -ms-touch-action: pan-x; touch-action: pan-x; }[touch-action="pan-y"]{ -ms-touch-action: pan-y; touch-action: pan-y; }[touch-action="scroll"],[touch-action="pan-x pan-y"],[touch-action="pan-y pan-x"]{ -ms-touch-action: pan-x pan-y; touch-action: pan-x pan-y; }</style></head>
-    <body id="index" class="home">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 
+		<link rel="stylesheet" href="images/plonematch.css" type="text/css" />
+		<style type="text/css">
+			[touch-action = "none"]{
+				-ms-touch-action:none;
+				touch-action:none;
+			}
+			[touch-action = "pan-x"]{
+				-ms-touch-action:pan-x;
+				touch-action:pan-x;
+			}
+			[touch-action = "pan-y"]{
+				-ms-touch-action:pan-y;
+				touch-action:pan-y;
+			}
+			[touch-action = "scroll"],
+			[touch-action = "pan-x pan-y"],
+			[touch-action = "pan-y pan-x"]{
+				-ms-touch-action:pan-x pan-y;
+				touch-action:pan-x pan-y;
+			}</style>
+		<title></title>
+	</head>
+	<body id="index" class="home">
 		<!-- OME Banner - START -->
 		<div id="portal-top">
 			<div id="portal-header">
 				<ul id="portal-siteactions">
 					<li>
-						<br>
+						<br />
 					</li>
-				</ul><a id="portal-logo" accesskey="1" href="http://downloads.openmicroscopy.org/" name="portal-logo"><img src="images/logo.jpg" alt="" title="" height="73" width="450"></a>
-			  <div id="portal-globalnav">
-					<br>
+				</ul><a id="portal-logo" accesskey="1" href="http://downloads.openmicroscopy.org/"
+					name="portal-logo"><img src="images/logo.jpg" alt="" title="" height="73"
+						width="450" /></a>
+				<div id="portal-globalnav">
+					<br />
 				</div>
 			</div>
 			<div id="portal-personaltools-wrapper">
 				<ul id="portal-personaltools" class="visualInline">
 					<li>
-						<br>
+						<br />
 					</li>
 				</ul>
 			</div>
 		</div>
 		<div class="visualClear" id="clear-space-before-wrapper-table">
-		<!-- OME Banner - END -->
+			<!-- OME Banner - END -->
+			<!-- /#menu -->
+			<!-- <section id="content" class="body" style="margin-left:20px;"> -->
+			<div class="entry-content">
+				<h2>u-track @VERSION@ Downloads</h2>
+				<ul>
+					<li>
+						<p>The software is currently distributed as a source code bundle and
+							requires MATLAB to be installed with some toolboxes described in the <a
+								href="@DOC@">PDF documentation</a>.</p>
+					</li>
+				</ul>
+				<h2><a name="code" id="code"></a>Downloads</h2>
+				<div class="alt-table">
+					<table width="800" border="0" cellpadding="5">
+						<tbody>
+							<tr>
+								<th width="269">Source Code</th>
+								<th width="91">Size</th>
+								<th width="270">File Name</th>
+								<th width="120">Checksum</th>
+							</tr>
+							<tr>
+								<td><a href="@SOURCE_CODE@" target="_blank"><img
+											src="images/utrack.png" alt="Zipped Source Code"
+									 /></a></td>
+								<td align="center">@SOURCE_CODE_SIZE@</td>
+								<td>@SOURCE_CODE_BASE@</td>
+								<td align="center">@SOURCE_CODE_MD5@ (<a href="@SOURCE_CODE@.md5"
+										>MD5</a>)</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<ul>
+					<li>
+						<p>To use u-track with OMERO, you will need to download the OMERO.matlab
+							toolbox for the same OMERO release number as your server from the <a
+								href="http://downloads.openmicroscopy.org/omero">OMERO downloads
+								folders</a> in addition to the zipped code.</p>
+					</li>
+					<li>
+						<p>To get started, download the zipped code, unextract it and add it with
+							its subfolders to your MATLAB path. Then launch the software by entering
+								<code>movieSelectorGUI</code> at the MATLAB command prompt.</p>
+					</li>
 
-                                  <!-- /#menu -->
-<section id="content" class="body" style="margin-left:20px;">
-
-<div class="entry-content">
-
-<h2>u-track @VERSION@ Downloads</h2>
-
-<ul>
-<li>
-<p>The software is currently distributed as a source code bundle and requires MATLAB to be installed with some toolboxes described in the <a href="@DOC@">PDF documentation</a>.</p>
-</li>
-</ul>
-
-<h2><a name="code" id="code"></a>Downloads</h2>
-
-<div class="alt-table">
-<table width="800" border="0" cellpadding="5">
-  <tbody>
-    <tr>
-      <th width="269">Source Code</th>
-      <th width="91">Size</th>
-      <th width="270">File Name</th>
-      <th width="120">Checksum</th>
-      </tr>
-    <tr>
-      <td><a href="@SOURCE_CODE@" target="_blank"><img src="images/utrack.png" alt="Zipped Source Code" /></a></td>
-      <td align="center">@SOURCE_CODE_SIZE@</td>
-      <td>@SOURCE_CODE_BASE@</td>
-      <td align="center">@SOURCE_CODE_MD5@ (<a href="@SOURCE_CODE@.md5">MD5</a>)</td>
-      </tr>
-  </tbody>
-</table>
-</div>
-
-<ul>
-<li>
-<p>To use u-track with OMERO, you will need to download the OMERO.matlab toolbox for the same OMERO release number as your server from the <a href="http://downloads.openmicroscopy.org/omero">OMERO downloads folders</a> in addition to the zipped code.</p>
-</li>
-<li>
-<p>To get started, download the zipped code, unextract it and add it with its subfolders to your MATLAB path. Then launch the software by entering <code>movieSelectorGUI</code> at the MATLAB command prompt.</p>
-</li>
-
-</ul>
-
-<h2><a name="legacy" id="legacy"></a>Previous versions</h2>
-
-<ul>
-  <li>
-<p>We recommend that you always use the most recent release version of the u-track software, but if you need to use a previous version, they are all available from the main <a href="http://downloads.openmicroscopy.org/u-track/?C=M;O=D">downloads folder</a>.</p>
-  </li>
-</ul>
-  
-  </div><!-- /.entry-content -->
-</section>
-        <footer id="contentinfo" class="body">
-        </footer><!-- /#contentinfo -->
-
-		<!-- OME Footer - Start -->
-		<div class="visualClear" id="clear-space-before-footer"><!-- --></div>
-		<div id="portal-footer">
-			<p>
-				<acronym title="Copyright">&copy;</acronym>
-				2000-2014
-				University of Dundee &amp; Open Microscopy Environment. <a href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing">Creative Commons Attribution 3.0 Unported License</a>
-			</p>
-			<p>
-				OME source code is available under the <a href="http://www.openmicroscopy.org/site/about/licensing">GNU General public license</a> or through commercial license from <a href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software">Glencoe Software</a>
-			</p>
+				</ul>
+				<h2><a name="legacy" id="legacy"></a>Previous versions</h2>
+				<ul>
+					<li>
+						<p>We recommend that you always use the most recent release version of the
+							u-track software, but if you need to use a previous version, they are
+							all available from the main <a
+								href="http://downloads.openmicroscopy.org/u-track/?C=M;O=D"
+								>downloads folder</a>.</p>
+					</li>
+				</ul>
+			</div><!-- /.entry-content -->
+			<!-- </section> -->
+			<!-- <footer id="contentinfo" class="body">
+			</footer> --><!-- /#contentinfo -->
+			<!-- OME Footer - Start -->
+			<div class="visualClear" id="clear-space-before-footer"><!-- --></div>
+			<div id="portal-footer">
+				<p>
+					<acronym title="Copyright">&copy;</acronym> 2000-2014 University of Dundee &amp;
+					Open Microscopy Environment. <a
+						href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
+						>Creative Commons Attribution 3.0 Unported License</a>
+				</p>
+				<p> OME source code is available under the <a
+						href="http://www.openmicroscopy.org/site/about/licensing">GNU General public
+						license</a> or through commercial license from <a
+						href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software"
+						>Glencoe Software</a>
+				</p>
+			</div>
+			<div class="visualClear">
+				<!-- OME Footer - END -->
+			</div>
 		</div>
-		<div class="visualClear">
-		<!-- OME Footer - END -->
-	
-</div></div></body></html>
+	</body>
+</html>

--- a/utrack_downloads.html
+++ b/utrack_downloads.html
@@ -51,9 +51,7 @@
         </div>
         <div class="visualClear" id="clear-space-before-wrapper-table">
             <!-- OME Banner - END -->
-            <!-- /#menu -->
-            <!-- <section id="content" class="body" style="margin-left:20px;"> -->
-            <div class="entry-content">
+            <div class="entry-content" style="margin-left:20px;">
                 <h2>u-track @VERSION@ Downloads</h2>
                 <ul>
                     <li>
@@ -115,9 +113,7 @@
                     </li>
                 </ul>
             </div><!-- /.entry-content -->
-            <!-- </section> -->
-            <!-- <footer id="contentinfo" class="body">
-			</footer> --><!-- /#contentinfo -->
+
             <!-- OME Footer - Start -->
             <div class="visualClear" id="clear-space-before-footer"
                 ><!-- --></div>

--- a/webtagging_downloads.html
+++ b/webtagging_downloads.html
@@ -78,7 +78,7 @@
                 </ul>
                 <h2>Downloads</h2>
                 <div class="alt-table">
-                    <table width="800" border="0" cellpadding="5">
+                    <table width="800" border="0" cellpadding="5" summary="Downloads">
                         <tbody>
                             <tr>
                                 <th width="269">File</th>

--- a/webtagging_downloads.html
+++ b/webtagging_downloads.html
@@ -1,121 +1,129 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
-	<head>
-		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 
-		<link rel="stylesheet" href="images/plonematch.css" type="text/css" />
+        <link rel="stylesheet" href="images/plonematch.css" type="text/css" />
 
-		<style type="text/css">
-			[touch-action = "none"]{
-				-ms-touch-action:none;
-				touch-action:none;
-			}
-			[touch-action = "pan-x"]{
-				-ms-touch-action:pan-x;
-				touch-action:pan-x;
-			}
-			[touch-action = "pan-y"]{
-				-ms-touch-action:pan-y;
-				touch-action:pan-y;
-			}
-			[touch-action = "scroll"],
-			[touch-action = "pan-x pan-y"],
-			[touch-action = "pan-y pan-x"]{
-				-ms-touch-action:pan-x pan-y;
-				touch-action:pan-x pan-y;
-			}</style>
-		<title></title>
-	</head>
-	<body id="index" class="home">
-		<!-- OME Banner - START -->
-		<div id="portal-top">
-			<div id="portal-header">
-				<ul id="portal-siteactions">
-					<li>
-						<br />
-					</li>
-				</ul><a id="portal-logo" accesskey="1" href="http://downloads.openmicroscopy.org/"
-					name="portal-logo"><img src="images/logo.jpg" alt="" title="" height="73"
-						width="450" /></a>
-				<div id="portal-globalnav">
-					<br />
-				</div>
-			</div>
-			<div id="portal-personaltools-wrapper">
-				<ul id="portal-personaltools" class="visualInline">
-					<li>
-						<br />
-					</li>
-				</ul>
-			</div>
-		</div>
-		<div class="visualClear" id="clear-space-before-wrapper-table">
-			<!-- OME Banner - END -->
-			<!-- /#menu -->
-			<!-- <section id="content" class="body" style="margin-left:20px;"> -->
-			<div class="entry-content">
-				<h2>OMERO.webtagging @VERSION@</h2>
-				<ul>
-					<li>
-						<p>Information on this release of OMERO.webtagging is in the <a
-								href="@ANNOUCEMENT_URL@">release announcement</a>. </p>
-					</li>
+        <style type="text/css">
+            [touch-action = "none"]{
+                -ms-touch-action:none;
+                touch-action:none;
+            }
+            [touch-action = "pan-x"]{
+                -ms-touch-action:pan-x;
+                touch-action:pan-x;
+            }
+            [touch-action = "pan-y"]{
+                -ms-touch-action:pan-y;
+                touch-action:pan-y;
+            }
+            [touch-action = "scroll"],
+            [touch-action = "pan-x pan-y"],
+            [touch-action = "pan-y pan-x"]{
+                -ms-touch-action:pan-x pan-y;
+                touch-action:pan-x pan-y;
+            }</style>
+        <title></title>
+    </head>
+    <body id="index" class="home">
+        <!-- OME Banner - START -->
+        <div id="portal-top">
+            <div id="portal-header">
+                <ul id="portal-siteactions">
+                    <li>
+                        <br />
+                    </li>
+                </ul><a id="portal-logo" accesskey="1"
+                    href="http://downloads.openmicroscopy.org/"
+                    name="portal-logo"><img src="images/logo.jpg" alt=""
+                        title="" height="73" width="450" /></a>
+                <div id="portal-globalnav">
+                    <br />
+                </div>
+            </div>
+            <div id="portal-personaltools-wrapper">
+                <ul id="portal-personaltools" class="visualInline">
+                    <li>
+                        <br />
+                    </li>
+                </ul>
+            </div>
+        </div>
+        <div class="visualClear" id="clear-space-before-wrapper-table">
+            <!-- OME Banner - END -->
+            <!-- /#menu -->
+            <!-- <section id="content" class="body" style="margin-left:20px;"> -->
+            <div class="entry-content">
+                <h2>OMERO.webtagging @VERSION@</h2>
+                <ul>
+                    <li>
+                        <p>Information on this release of OMERO.webtagging is in
+                            the <a href="@ANNOUCEMENT_URL@">release
+                                announcement</a>. </p>
+                    </li>
 
-					<li>
-						<p>Full documentation is available as <a
-								href="http://www.openmicroscopy.org/site/support/partner/omero.webtagging"
-								>web documentation</a>.</p>
-					</li>
+                    <li>
+                        <p>Full documentation is available as <a
+                                href="http://www.openmicroscopy.org/site/support/partner/omero.webtagging"
+                                >web documentation</a>.</p>
+                    </li>
 
-					<li>
-						<p>Source code and the latest development version can always be found on <a
-								href="https://github.com/dpwrussell/webtagging">GitHub</a>.</p>
-					</li>
-				</ul>
-				<h2>Downloads</h2>
-				<div class="alt-table">
-					<table width="800" border="0" cellpadding="5">
-						<tbody>
-							<tr>
-								<th width="269">File</th>
-								<th width="85">Size</th>
-								<th width="271">File Name</th>
-								<th width="125">Checksum</th>
-							</tr>
-							<tr>
-								<td><a href="@WEBTAGGING@"><img src="images/omero_webtagging.png"
-											alt="OMERO.webtagging Download" /></a></td>
-								<td align="center">@WEBTAGGING_SIZE@</td>
-								<td>@WEBTAGGING_BASE@</td>
-								<td align="center">@WEBTAGGING_MD5@ (<a href="@WEBTAGGING@.md5"
-										>MD5</a>)</td>
-							</tr>
-						</tbody>
-					</table>
-				</div>
-			</div><!-- /.entry-content -->
-			<!-- </section> -->
-			<!-- <footer id="contentinfo" class="body">
+                    <li>
+                        <p>Source code and the latest development version can
+                            always be found on <a
+                                href="https://github.com/dpwrussell/webtagging"
+                                >GitHub</a>.</p>
+                    </li>
+                </ul>
+                <h2>Downloads</h2>
+                <div class="alt-table">
+                    <table width="800" border="0" cellpadding="5">
+                        <tbody>
+                            <tr>
+                                <th width="269">File</th>
+                                <th width="85">Size</th>
+                                <th width="271">File Name</th>
+                                <th width="125">Checksum</th>
+                            </tr>
+                            <tr>
+                                <td><a href="@WEBTAGGING@"><img
+                                        src="images/omero_webtagging.png"
+                                        alt="OMERO.webtagging Download"
+                                     /></a></td>
+                                <td align="center">@WEBTAGGING_SIZE@</td>
+                                <td>@WEBTAGGING_BASE@</td>
+                                <td align="center">@WEBTAGGING_MD5@ (<a
+                                        href="@WEBTAGGING@.md5">MD5</a>)</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div><!-- /.entry-content -->
+            <!-- </section> -->
+            <!-- <footer id="contentinfo" class="body">
         </footer> --><!-- /#contentinfo -->
-			<!-- OME Footer - Start -->
-			<div class="visualClear" id="clear-space-before-footer"><!-- --></div>
-			<div id="portal-footer">
-				<p>
-					<acronym title="Copyright">&copy;</acronym> 2000-2014 University of Dundee &amp;
-					Open Microscopy Environment. <a
-						href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
-						>Creative Commons Attribution 3.0 Unported License</a>
-				</p>
-				<p> OME source code is available under the <a
-						href="http://www.openmicroscopy.org/site/about/licensing">GNU General public
-						license</a> or through commercial license from <a
-						href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software"
-						>Glencoe Software</a>
-				</p>
-			</div>
-			<div class="visualClear">
-				<!-- OME Footer - END -->
-			</div>
-		</div>
-	</body>
+            <!-- OME Footer - Start -->
+            <div class="visualClear" id="clear-space-before-footer"
+                ><!-- --></div>
+            <div id="portal-footer">
+                <p>
+                    <acronym title="Copyright">&copy;</acronym> 2000-2014
+                    University of Dundee &amp; Open Microscopy Environment. <a
+                        href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
+                        >Creative Commons Attribution 3.0 Unported License</a>
+                </p>
+                <p> OME source code is available under the <a
+                        href="http://www.openmicroscopy.org/site/about/licensing"
+                        >GNU General public license</a> or through commercial
+                    license from <a
+                        href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software"
+                        >Glencoe Software</a>
+                </p>
+            </div>
+            <div class="visualClear">
+                <!-- OME Footer - END -->
+            </div>
+        </div>
+    </body>
 </html>

--- a/webtagging_downloads.html
+++ b/webtagging_downloads.html
@@ -1,98 +1,121 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-        
-        <link rel="stylesheet" href="images/plonematch.css" type="text/css">
-        <meta charset="utf-8">
-          
-  
-      <meta name="tags" contents="flimfit">
-  
-    <style type="text/css"></style><style>[touch-action="none"]{ -ms-touch-action: none; touch-action: none; }[touch-action="pan-x"]{ -ms-touch-action: pan-x; touch-action: pan-x; }[touch-action="pan-y"]{ -ms-touch-action: pan-y; touch-action: pan-y; }[touch-action="scroll"],[touch-action="pan-x pan-y"],[touch-action="pan-y pan-x"]{ -ms-touch-action: pan-x pan-y; touch-action: pan-x pan-y; }</style></head>
-    <body id="index" class="home">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 
+		<link rel="stylesheet" href="images/plonematch.css" type="text/css" />
+
+		<style type="text/css">
+			[touch-action = "none"]{
+				-ms-touch-action:none;
+				touch-action:none;
+			}
+			[touch-action = "pan-x"]{
+				-ms-touch-action:pan-x;
+				touch-action:pan-x;
+			}
+			[touch-action = "pan-y"]{
+				-ms-touch-action:pan-y;
+				touch-action:pan-y;
+			}
+			[touch-action = "scroll"],
+			[touch-action = "pan-x pan-y"],
+			[touch-action = "pan-y pan-x"]{
+				-ms-touch-action:pan-x pan-y;
+				touch-action:pan-x pan-y;
+			}</style>
+		<title></title>
+	</head>
+	<body id="index" class="home">
 		<!-- OME Banner - START -->
 		<div id="portal-top">
 			<div id="portal-header">
 				<ul id="portal-siteactions">
 					<li>
-						<br>
+						<br />
 					</li>
-				</ul><a id="portal-logo" accesskey="1" href="http://downloads.openmicroscopy.org/" name="portal-logo"><img src="images/logo.jpg" alt="" title="" height="73" width="450"></a>
-			  <div id="portal-globalnav">
-					<br>
+				</ul><a id="portal-logo" accesskey="1" href="http://downloads.openmicroscopy.org/"
+					name="portal-logo"><img src="images/logo.jpg" alt="" title="" height="73"
+						width="450" /></a>
+				<div id="portal-globalnav">
+					<br />
 				</div>
 			</div>
 			<div id="portal-personaltools-wrapper">
 				<ul id="portal-personaltools" class="visualInline">
 					<li>
-						<br>
+						<br />
 					</li>
 				</ul>
 			</div>
 		</div>
 		<div class="visualClear" id="clear-space-before-wrapper-table">
-		<!-- OME Banner - END -->
+			<!-- OME Banner - END -->
+			<!-- /#menu -->
+			<!-- <section id="content" class="body" style="margin-left:20px;"> -->
+			<div class="entry-content">
+				<h2>OMERO.webtagging @VERSION@</h2>
+				<ul>
+					<li>
+						<p>Information on this release of OMERO.webtagging is in the <a
+								href="@ANNOUCEMENT_URL@">release announcement</a>. </p>
+					</li>
 
-                                  <!-- /#menu -->
-<section id="content" class="body" style="margin-left:20px;">
+					<li>
+						<p>Full documentation is available as <a
+								href="http://www.openmicroscopy.org/site/support/partner/omero.webtagging"
+								>web documentation</a>.</p>
+					</li>
 
-<div class="entry-content">
-
-<h2>OMERO.webtagging @VERSION@</h2>
-
-<ul>
-<li>
-<p>Information on this release of OMERO.webtagging is in the <a href="@ANNOUCEMENT_URL@">release announcement</a>. </p>
-</li>
-
-<li>
-<p>Full documentation is available as <a href="http://www.openmicroscopy.org/site/support/partner/omero.webtagging">web documentation</a>.</p>
-</li>
-
-<li>
-<p>Source code and the latest development version can always be found on <a href="https://github.com/dpwrussell/webtagging">GitHub</a>.</p>
-</li>
-</ul>
-
-<h2>Downloads</h2>
-
-<div class="alt-table">
-  <table width="800" border="0" cellpadding="5">
-    <tbody>
-      <tr>
-        <th width="269">File</th>
-        <th width="85">Size</th>
-        <th width="271">File Name</th>
-        <th width="125">Checksum</th>
-        </tr>
-      <tr>
-        <td><a href="@WEBTAGGING@"><img src="images/omero_webtagging.png" alt="OMERO.webtagging Download" /></a></td>
-        <td align="center">@WEBTAGGING_SIZE@</td>
-        <td>@WEBTAGGING_BASE@</td>
-        <td align="center">@WEBTAGGING_MD5@ (<a href="@WEBTAGGING@.md5">MD5</a>)</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-  
-  </div><!-- /.entry-content -->
-</section>
-        <footer id="contentinfo" class="body">
-        </footer><!-- /#contentinfo -->
-
-		<!-- OME Footer - Start -->
-		<div class="visualClear" id="clear-space-before-footer"><!-- --></div>
-		<div id="portal-footer">
-			<p>
-				<acronym title="Copyright">&copy;</acronym>
-				2000-2014
-				University of Dundee &amp; Open Microscopy Environment. <a href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing">Creative Commons Attribution 3.0 Unported License</a>
-			</p>
-			<p>
-				OME source code is available under the <a href="http://www.openmicroscopy.org/site/about/licensing">GNU General public license</a> or through commercial license from <a href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software">Glencoe Software</a>
-			</p>
+					<li>
+						<p>Source code and the latest development version can always be found on <a
+								href="https://github.com/dpwrussell/webtagging">GitHub</a>.</p>
+					</li>
+				</ul>
+				<h2>Downloads</h2>
+				<div class="alt-table">
+					<table width="800" border="0" cellpadding="5">
+						<tbody>
+							<tr>
+								<th width="269">File</th>
+								<th width="85">Size</th>
+								<th width="271">File Name</th>
+								<th width="125">Checksum</th>
+							</tr>
+							<tr>
+								<td><a href="@WEBTAGGING@"><img src="images/omero_webtagging.png"
+											alt="OMERO.webtagging Download" /></a></td>
+								<td align="center">@WEBTAGGING_SIZE@</td>
+								<td>@WEBTAGGING_BASE@</td>
+								<td align="center">@WEBTAGGING_MD5@ (<a href="@WEBTAGGING@.md5"
+										>MD5</a>)</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+			</div><!-- /.entry-content -->
+			<!-- </section> -->
+			<!-- <footer id="contentinfo" class="body">
+        </footer> --><!-- /#contentinfo -->
+			<!-- OME Footer - Start -->
+			<div class="visualClear" id="clear-space-before-footer"><!-- --></div>
+			<div id="portal-footer">
+				<p>
+					<acronym title="Copyright">&copy;</acronym> 2000-2014 University of Dundee &amp;
+					Open Microscopy Environment. <a
+						href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
+						>Creative Commons Attribution 3.0 Unported License</a>
+				</p>
+				<p> OME source code is available under the <a
+						href="http://www.openmicroscopy.org/site/about/licensing">GNU General public
+						license</a> or through commercial license from <a
+						href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software"
+						>Glencoe Software</a>
+				</p>
+			</div>
+			<div class="visualClear">
+				<!-- OME Footer - END -->
+			</div>
 		</div>
-		<div class="visualClear">
-		<!-- OME Footer - END -->
-	
-</div></div></body></html>
+	</body>
+</html>

--- a/webtagging_downloads.html
+++ b/webtagging_downloads.html
@@ -52,9 +52,7 @@
         </div>
         <div class="visualClear" id="clear-space-before-wrapper-table">
             <!-- OME Banner - END -->
-            <!-- /#menu -->
-            <!-- <section id="content" class="body" style="margin-left:20px;"> -->
-            <div class="entry-content">
+        	<div class="entry-content" style="margin-left:20px;">
                 <h2>OMERO.webtagging @VERSION@</h2>
                 <ul>
                     <li>
@@ -100,10 +98,8 @@
                     </table>
                 </div>
             </div><!-- /.entry-content -->
-            <!-- </section> -->
-            <!-- <footer id="contentinfo" class="body">
-        </footer> --><!-- /#contentinfo -->
-            <!-- OME Footer - Start -->
+
+        	<!-- OME Footer - Start -->
             <div class="visualClear" id="clear-space-before-footer"
                 ><!-- --></div>
             <div id="portal-footer">


### PR DESCRIPTION
This is the same as gh-94 but rebased onto develop.

---

I cleaned up the files, fixed validation errors and formatted them.

They need tested, there were some invalid tokens I have commented out, but they might have been important to some build system as markers.

Need checked by @sbesson and @hflynn

Oh, and why are there two `flimfit_downloads.html`?
