### PR TITLE
Add button to Bio-Formats source code under downloads.oo.org (rebased onto develop)

### DIFF
--- a/bf_downloads.html
+++ b/bf_downloads.html
@@ -368,10 +368,31 @@
                 </div>
                 <h2><a name="code" id="code"></a>Source code</h2>
                 <div class="alt-table">
-                    <table width="278" border="0" cellpadding="5" summary="Source code">
+                    <table width="800" border="0" cellpadding="5" summary="Bio-Formats Code">
                         <tbody>
                             <tr>
-                                <th width="264">Source Code</th>
+                                <th width="269">Source Code</th>
+                                <th width="91">Size</th>
+                                <th width="270">File Name</th>
+                                <th width="120">Checksum</th>
+                            </tr>
+                            <tr>
+                                <td><a href="@SOURCE_CODE@" target="_blank"><img
+                                        src="images/ome_source_code.png"
+                                        alt="Zipped Source Code" /></a></td>
+                                <td align="center">@SOURCE_CODE_SIZE@</td>
+                                <td>@SOURCE_CODE_BASE@</td>
+                                <td align="center">@SOURCE_CODE_MD5@ (<a
+                                        href="@SOURCE_CODE@.md5">MD5</a>)</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <div class="alt-table">
+                    <table width="278" border="0" cellpadding="5" summary="Bio-Formats Code links">
+                        <tbody>
+                            <tr>
+                                <th width="264">Source Code Links</th>
                             </tr>
                             <tr>
                                 <td><a

--- a/bfgen.py
+++ b/bfgen.py
@@ -67,6 +67,7 @@ for x, y in (
         ("MATLAB_TOOLS", "artifacts/bfmatlab.zip"),
         ("DOC", "artifacts/Bio-Formats-@VERSION@.pdf"),
         ("JAVADOCS", "artifacts/bio-formats-javadocs.zip"),
+        ("SOURCE_CODE", "artifacts/bioformats-@VERSION@.zip"),
         ("bioformats_package.jar", "artifacts/bioformats_package.jar"),
         ("bio-formats_plugins.jar", "artifacts/bio-formats_plugins.jar"),
         ("bio-formats-testing-framework.jar",


### PR DESCRIPTION
This is the same as gh-96 but rebased onto develop.

---

This PR reuses the source code table from the OMERO downloads page to expose the source code zip produced by the release code in the main downloads page.

/cc @rleigh-dundee
