### PR TITLE
Update FLIMfit downloads page for 4.6.6 release (rebased onto develop)

### DIFF
--- a/flimfit_downloads.html
+++ b/flimfit_downloads.html
@@ -119,6 +119,17 @@
                                         href="@FLIMFIT_50_MAC@.md5"
                                     >MD5</a>)</td>
                             </tr>
+                            <tr>
+                                <td><a href="@FLIMFIT_50_WIN@"><img
+                                        src="images/flimfit_win.png"
+                                        alt="Windows Client Download"
+                                     /></a></td>
+                                <td align="center">@FLIMFIT_50_WIN_SIZE@</td>
+                                <td>@FLIMFIT_50_WIN_BASE@</td>
+                                <td align="center">@FLIMFIT_50_WIN_MD5@ (<a
+                                        href="@FLIMFIT_50_WIN@.md5"
+                                    >MD5</a>)</td>
+                            </tr>
                         </tbody>
                     </table>
                 </div>
@@ -142,6 +153,17 @@
                                 <td>@FLIMFIT_44_MAC_BASE@</td>
                                 <td align="center">@FLIMFIT_44_MAC_MD5@ (<a
                                         href="@FLIMFIT_44_MAC@.md5"
+                                    >MD5</a>)</td>
+                            </tr>
+                            <tr>
+                                <td><a href="@FLIMFIT_44_WIN@"><img
+                                        src="images/flimfit_win.png"
+                                        alt="Windows Client Download"
+                                     /></a></td>
+                                <td align="center">@FLIMFIT_44_WIN_SIZE@</td>
+                                <td>@FLIMFIT_44_WIN_BASE@</td>
+                                <td align="center">@FLIMFIT_44_WIN_MD5@ (<a
+                                        href="@FLIMFIT_44_WIN@.md5"
                                     >MD5</a>)</td>
                             </tr>
                         </tbody>

--- a/flimfit_downloads.html
+++ b/flimfit_downloads.html
@@ -96,14 +96,6 @@
                             download either version (for 4.4.x or 5.0.x) as
                             there will be no difference in stand-alone mode.</p>
                     </li>
-                    <li>
-                        <p>Windows users please note that there is currently no
-                            pre-compiled binary of 4.6.4 for OMERO 5.0.x due to
-                            reported problems connecting to 5.0.0 servers from
-                            FLIMfit on some Windows variants. It is, however,
-                            possible to use FLIMfit from the MATLAB source on
-                            GitHub by following the link below.</p>
-                    </li>
                 </ul>
                 <h2><a name="flimfit_50" id="flimfit_50"></a>FLIMfit downloads
                     for OMERO 5.0.x</h2>

--- a/flimfit_downloads.html
+++ b/flimfit_downloads.html
@@ -51,26 +51,29 @@
         </div>
         <div class="visualClear" id="clear-space-before-wrapper-table">
             <!-- OME Banner - END -->
-        	<div class="entry-content" style="margin-left:20px;">
+            <div class="entry-content" style="margin-left:20px;">
                 <h2>FLIMfit @VERSION@ Downloads</h2>
                 <p>
                     <strong><a href="#flimfit_50">OMERO
                             5.0</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
                             href="#flimfit_44">OMERO
-                            4.4</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#code"
-                            >Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
+                            4.4</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
+                            href="#mcr">MCR</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
+                            href="#code">Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
                             href="#previous">Previous versions</a>
                     </strong></p>
                 <ul>
                     <li>
                         <p>Mac users, please note that in order to run FLIMfit
-                            you will need the MATLAB Compiler Runtime (MCR)
-                            which enables the execution of compiled MATLAB
-                            applications or components on computers that do not
-                            have MATLAB installed. It can be downloaded from <a
-                                href="http://www.mathworks.co.uk/products/compiler/mcr/"
-                                >MATLAB Compiler Runtime (MCR)</a>. The Windows
-                            Installer will automatically install the MCR. </p>
+                            you will need the correct MCR (MATLAB Compiler
+                            Runtime) installed on your system (currently
+                            2013b, v8.2) which enables the execution of
+                            compiled MATLAB applications or components on
+                            computers that do not have MATLAB installed. If
+                            you do not, or are in any doubt, please also
+                            download the MCR for your platform <a href="#mcr">
+                            below</a>. The Windows Installer will
+                            automatically install the MCR. </p>
                     </li>
 
                     <li>
@@ -169,6 +172,28 @@
                         </tbody>
                     </table>
                 </div>
+                <h2><a name="mcr" id="mcr"></a>MCR downloads</h2>
+                <div class="alt-table">
+                    <table width="269" border="0" cellpadding="5" summary="MCR Downloads">
+                        <tbody>
+                            <tr>
+                                <th width="269">MCR</th>
+                            </tr>
+                            <tr>
+                                <td><a href="@MCR_WIN@"><img
+                                        src="images/mcr_windows.png"
+                                        alt="Windows MCR Download"
+                                     /></a></td>
+                            </tr>
+                            <tr>
+                                <td><a href="@MCR_MAC@"><img
+                                        src="images/mcr_mac.png"
+                                        alt="Mac OS X MCR Download"
+                                     /></a></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
                 <h2><a name="code" id="code"></a>Checking out the code</h2>
                 <div class="alt-table">
                     <table width="278" border="0" cellpadding="5" summary="FLIMfit Source Code">
@@ -199,7 +224,7 @@
                 </ul>
             </div><!-- /.entry-content -->
 
-        	<!-- OME Footer - Start -->
+            <!-- OME Footer - Start -->
             <div class="visualClear" id="clear-space-before-footer"
                 ><!-- --></div>
             <div id="portal-footer">

--- a/flimfitgen.py
+++ b/flimfitgen.py
@@ -29,6 +29,13 @@ RSYNC_PATH = os.environ.get('RSYNC_PATH', '/ome/data_repo/public/')
 PREFIX = os.environ.get('PREFIX', 'flimfit')
 FLIMFIT_RSYNC_PATH = '%s/%s/%s/' % (RSYNC_PATH, PREFIX, version)
 
+# Links to the MCR downloads
+repl["@WIN_MCR@"] = "http://www.mathworks.com/supportfiles/downloads/R2013b" \
+    "/deployment_files/R2013b/installers/win64/MCR_R2013b_win64_installer.exe"
+repl["@WIN_MCR@"] = "http://www.mathworks.com/supportfiles/downloads/R2013b" \
+    "/deployment_files/R2013b/installers/maci64" \
+    "/MCR_R2013b_maci64_installer.zip"
+
 for x, y in (
         ("FLIMFIT_50_WIN", "artifacts/FLIMFit_@VERSION@_OME_5.0_x64.zip"),
         ("FLIMFIT_50_MAC", "artifacts/FLIMfit_@VERSION@_OME_5.0_MACI64.zip"),

--- a/flimfitgen.py
+++ b/flimfitgen.py
@@ -30,9 +30,9 @@ PREFIX = os.environ.get('PREFIX', 'flimfit')
 FLIMFIT_RSYNC_PATH = '%s/%s/%s/' % (RSYNC_PATH, PREFIX, version)
 
 for x, y in (
-        # ("FLIMFIT_50_WIN", "artifacts/FLIMFit-@VERSION@-OME-5.0.win.zip"),
+        ("FLIMFIT_50_WIN", "artifacts/FLIMFit_@VERSION@_OME_5.0_x64.zip"),
         ("FLIMFIT_50_MAC", "artifacts/FLIMfit_@VERSION@_OME_5.0_MACI64.zip"),
-        # ("FLIMFIT_44_WIN", "artifacts/FLIMFit-@VERSION@-OME-4.4.win.zip"),
+        ("FLIMFIT_44_WIN", "artifacts/FLIMFit_@VERSION@_OME_4.4_x64.zip"),
         ("FLIMFIT_44_MAC", "artifacts/FLIMfit_@VERSION@_OME_4.4_MACI64.zip"),
         ):
 

--- a/flimfitgen.py
+++ b/flimfitgen.py
@@ -30,9 +30,9 @@ PREFIX = os.environ.get('PREFIX', 'flimfit')
 FLIMFIT_RSYNC_PATH = '%s/%s/%s/' % (RSYNC_PATH, PREFIX, version)
 
 # Links to the MCR downloads
-repl["@WIN_MCR@"] = "http://www.mathworks.com/supportfiles/downloads/R2013b" \
+repl["@MCR_WIN@"] = "http://www.mathworks.com/supportfiles/downloads/R2013b" \
     "/deployment_files/R2013b/installers/win64/MCR_R2013b_win64_installer.exe"
-repl["@WIN_MCR@"] = "http://www.mathworks.com/supportfiles/downloads/R2013b" \
+repl["@MCR_MAC@"] = "http://www.mathworks.com/supportfiles/downloads/R2013b" \
     "/deployment_files/R2013b/installers/maci64" \
     "/MCR_R2013b_maci64_installer.zip"
 

--- a/flimfitgen.py
+++ b/flimfitgen.py
@@ -37,9 +37,9 @@ repl["@WIN_MCR@"] = "http://www.mathworks.com/supportfiles/downloads/R2013b" \
     "/MCR_R2013b_maci64_installer.zip"
 
 for x, y in (
-        ("FLIMFIT_50_WIN", "artifacts/FLIMFit_@VERSION@_OME_5.0_x64.zip"),
+        ("FLIMFIT_50_WIN", "artifacts/FLIMfit_@VERSION@_OME_5.0_x64.zip"),
         ("FLIMFIT_50_MAC", "artifacts/FLIMfit_@VERSION@_OME_5.0_MACI64.zip"),
-        ("FLIMFIT_44_WIN", "artifacts/FLIMFit_@VERSION@_OME_4.4_x64.zip"),
+        ("FLIMFIT_44_WIN", "artifacts/FLIMfit_@VERSION@_OME_4.4_x64.zip"),
         ("FLIMFIT_44_MAC", "artifacts/FLIMfit_@VERSION@_OME_4.4_MACI64.zip"),
         ):
 


### PR DESCRIPTION
This is the same as gh-98 but rebased onto develop.

---
- Restore Windows downloads and remove 4.6.4-specific line 
- Add MCR downloads table and fix MCR sentence

/cc @imunro @hflynn
