### PR TITLE
Fix API weblink & MD5 link on BF downloads page

### DIFF
--- a/bf_downloads.html
+++ b/bf_downloads.html
@@ -175,7 +175,7 @@
                                 <td align="center">@JAVADOCS_SIZE@</td>
                                 <td>@JAVADOCS_BASE@</td>
                                 <td align="center">@JAVADOCS_MD5@ (<a
-                                        href="@DOCS@.md5">MD5</a>)</td>
+                                        href="@JAVADOCS@.md5">MD5</a>)</td>
                             </tr>
                         </tbody>
                     </table>
@@ -183,7 +183,7 @@
                 <ul>
                     <li>
                         <p>The Bio-Formats API documentation is also available
-                            to read on the web <a href="api">here</a></p>
+                            to read on the web <a href="api/">here</a></p>
                     </li>
                 </ul>
                 <h2><a name="components" id="components"></a>Bio-Formats


### PR DESCRIPTION
The API 'read on the web here' link and the MD5 link for the API docs zip downloads aren't working at present on http://downloads.openmicroscopy.org/bio-formats/5.0.1/#api
