### PR TITLE
Add downloads page for the custom Ice builds (rebased onto develop)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ mtools: mtoolsgen
 
 webtagging: webtagginggen
 
+ice: icegen
+
 gen:
 	mkdir -p $(CONTENTDIR)
 	python gen.py $(RELEASE) $(OMERO_BUILD) > $(CONTENTDIR)/index.html
@@ -68,6 +70,11 @@ mtoolsgen:
 webtagginggen:
 	mkdir -p $(CONTENTDIR)
 	python webtagginggen.py $(RELEASE) > $(CONTENTDIR)/index.html
+	cp -r $(IMAGESDIR) $(CONTENTDIR)
+
+icegen:
+	mkdir -p $(CONTENTDIR)
+	python icegen.py $(RELEASE) > $(CONTENTDIR)/index.html
 	cp -r $(IMAGESDIR) $(CONTENTDIR)
 
 html:

--- a/ice_downloads.html
+++ b/ice_downloads.html
@@ -58,40 +58,27 @@
 	                        &nbsp;&nbsp;|&nbsp;&nbsp;
 	                        <a href="#code">Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;
                     </strong></p>
-                <ul>
-                    <li>
-                        <p>Here a note about. </p>
-                    </li>
-
-                </ul>
                 <h2><a name="ice" id="ice"></a>Ice downloads for Windows</h2>
                 <div class="alt-table">
                     <table width="800" border="0" cellpadding="5" summary="Ice Downloads for Windows">
                         <tbody>
                             <tr>
-                                <th width="269">Clients</th>
+                                <th width="580">Downloads</th>
                                 <th width="85">Size</th>
-                                <th width="271">File Name</th>
                                 <th width="125">Checksum</th>
                             </tr>
                             <tr>
-                                <td><a href="@ICE_X64_WIN@"><img
-                                        src="images/ome_source_code.png"
-                                        alt="Ice Windows x64 Download"
-                                     /></a></td>
+                                <td><a href="@ICE_X64_WIN@">
+	                                   64-bit Ice for Windows x64 with 64-bit 
+	                                   Python 2.7</a></td>
                                 <td align="center">@ICE_X64_WIN_SIZE@</td>
-                                <td>@ICE_X64_WIN_BASE@</td>
                                 <td align="center">@ICE_X64_WIN_MD5@ (<a
                                         href="@ICE_X64_WIN@.md5"
                                     >MD5</a>)</td>
                             </tr>
                             <tr>
-                                <td><a href="@ICE_X86_WIN@"><img
-                                        src="images/ome_source_code.png"
-                                        alt="Windows Client Download"
-                                     /></a></td>
+                                <td><a href="@ICE_X86_WIN@">32-bit Ice for Windows x86 with 32-bit Python 2.7;</a></td>
                                 <td align="center">@ICE_X86_WIN_SIZE@</td>
-                                <td>@ICE_X86_WIN_BASE@</td>
                                 <td align="center">@ICE_X86_WIN_MD5@ (<a
                                         href="@ICE_X86_WIN@.md5"
                                     >MD5</a>)</td>
@@ -104,26 +91,19 @@
 	                    <table width="800" border="0" cellpadding="5" summary="OMERO Code">
 	                        <tbody>
 	                            <tr>
-	                                <th width="269">Source Code</th>
-	                                <th width="91">Size</th>
-	                                <th width="270">File Name</th>
-	                                <th width="120">Checksum</th>
+	                                <th width="580">Downloads</th>
+	                                <th width="85">Size</th>
+	                                <th width="125">Checksum</th>
 	                            </tr>
 	                            <tr>
-	                                <td><a href="@SOURCE_CODE@" target="_blank"><img
-	                                        src="images/ome_source_code.png"
-	                                        alt="Zipped Source Code" /></a></td>
+	                                <td><a href="@SOURCE_CODE@" target="_blank">Ice source code</a></td>
 	                                <td align="center">@SOURCE_CODE_SIZE@</td>
-	                                <td>@SOURCE_CODE_BASE@</td>
 	                                <td align="center">@SOURCE_CODE_MD5@ (<a
 	                                        href="@SOURCE_CODE@.md5">MD5</a>)</td>
 	                            </tr>
 	                            <tr>
-	                                <td><a href="@THIRD_PARTY@" target="_blank"><img
-	                                        src="images/ome_source_code.png"
-	                                        alt="Zipped Third Party Source Code" /></a></td>
+	                                <td><a href="@THIRD_PARTY@" target="_blank">Ice Third Party Source Code</a></td>
 	                                <td align="center">@THIRD_PARTY_SIZE@</td>
-	                                <td>@THIRD_PARTY_BASE@</td>
 	                                <td align="center">@THIRD_PARTY_MD5@ (<a
 	                                        href="@SOURCE_CODE@.md5">MD5</a>)</td>
 	                            </tr>

--- a/ice_downloads.html
+++ b/ice_downloads.html
@@ -102,7 +102,7 @@
 	                                        href="@SOURCE_CODE@.md5">MD5</a>)</td>
 	                            </tr>
 	                            <tr>
-	                                <td><a href="@THIRD_PARTY@" target="_blank">Ice Third Party Source Code</a></td>
+	                                <td><a href="@THIRD_PARTY@" target="_blank">Ice third party source code</a></td>
 	                                <td align="center">@THIRD_PARTY_SIZE@</td>
 	                                <td align="center">@THIRD_PARTY_MD5@ (<a
 	                                        href="@SOURCE_CODE@.md5">MD5</a>)</td>

--- a/ice_downloads.html
+++ b/ice_downloads.html
@@ -154,6 +154,5 @@
             <div class="visualClear">
                 <!-- OME Footer - END -->
             </div>
-        </div>
     </body>
 </html>

--- a/ice_downloads.html
+++ b/ice_downloads.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+
+        <link rel="stylesheet" href="images/plonematch.css" type="text/css" />
+        <style type="text/css">
+            [touch-action = "none"]{
+                -ms-touch-action:none;
+                touch-action:none;
+            }
+            [touch-action = "pan-x"]{
+                -ms-touch-action:pan-x;
+                touch-action:pan-x;
+            }
+            [touch-action = "pan-y"]{
+                -ms-touch-action:pan-y;
+                touch-action:pan-y;
+            }
+            [touch-action = "scroll"],
+            [touch-action = "pan-x pan-y"],
+            [touch-action = "pan-y pan-x"]{
+                -ms-touch-action:pan-x pan-y;
+                touch-action:pan-x pan-y;
+            }</style>
+        <title>Ice</title>
+    </head>
+    <body id="index" class="home">
+        <!-- OME Banner - START -->
+        <div id="portal-top">
+            <div id="portal-header">
+                <ul id="portal-siteactions">
+                    <li>
+                        <br />
+                    </li>
+                </ul><a id="portal-logo" accesskey="1"
+                    href="http://downloads.openmicroscopy.org/"
+                    name="portal-logo"><img src="images/logo.jpg" alt=""
+                        title="" height="73" width="450" /></a>
+                <div id="portal-globalnav">
+                    <br />
+                </div>
+            </div>
+            <div id="portal-personaltools-wrapper">
+                <ul id="portal-personaltools" class="visualInline">
+                    <li>
+                        <br />
+                    </li>
+                </ul>
+            </div>
+        </div>
+        <div class="visualClear" id="clear-space-before-wrapper-table">
+            <!-- OME Banner - END -->
+            <div class="entry-content" style="margin-left:20px;">
+                <h2>Ice @VERSION@ Downloads</h2>
+                <p>
+                    <strong><a href="#win">Windows downloads</a>
+	                        &nbsp;&nbsp;|&nbsp;&nbsp;
+	                        <a href="#code">Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;
+                    </strong></p>
+                <ul>
+                    <li>
+                        <p>Here a note about. </p>
+                    </li>
+
+                </ul>
+                <h2><a name="ice" id="ice"></a>Ice downloads for Windows</h2>
+                <div class="alt-table">
+                    <table width="800" border="0" cellpadding="5" summary="Ice Downloads for Windows">
+                        <tbody>
+                            <tr>
+                                <th width="269">Clients</th>
+                                <th width="85">Size</th>
+                                <th width="271">File Name</th>
+                                <th width="125">Checksum</th>
+                            </tr>
+                            <tr>
+                                <td><a href="@ICE_X64_WIN@"><img
+                                        src="images/ome_source_code.png"
+                                        alt="Ice Windows x64 Download"
+                                     /></a></td>
+                                <td align="center">@ICE_X64_WIN_SIZE@</td>
+                                <td>@ICE_X64_WIN_BASE@</td>
+                                <td align="center">@ICE_X64_WIN_MD5@ (<a
+                                        href="@ICE_X64_WIN@.md5"
+                                    >MD5</a>)</td>
+                            </tr>
+                            <tr>
+                                <td><a href="@ICE_X86_WIN@"><img
+                                        src="images/ome_source_code.png"
+                                        alt="Windows Client Download"
+                                     /></a></td>
+                                <td align="center">@ICE_X86_WIN_SIZE@</td>
+                                <td>@ICE_X86_WIN_BASE@</td>
+                                <td align="center">@ICE_X86_WIN_MD5@ (<a
+                                        href="@ICE_X86_WIN@.md5"
+                                    >MD5</a>)</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>    
+				<h2><a name="code" id="code"></a>Checking out the code</h2>
+	                <div class="alt-table">
+	                    <table width="800" border="0" cellpadding="5" summary="OMERO Code">
+	                        <tbody>
+	                            <tr>
+	                                <th width="269">Source Code</th>
+	                                <th width="91">Size</th>
+	                                <th width="270">File Name</th>
+	                                <th width="120">Checksum</th>
+	                            </tr>
+	                            <tr>
+	                                <td><a href="@SOURCE_CODE@" target="_blank"><img
+	                                        src="images/ome_source_code.png"
+	                                        alt="Zipped Source Code" /></a></td>
+	                                <td align="center">@SOURCE_CODE_SIZE@</td>
+	                                <td>@SOURCE_CODE_BASE@</td>
+	                                <td align="center">@SOURCE_CODE_MD5@ (<a
+	                                        href="@SOURCE_CODE@.md5">MD5</a>)</td>
+	                            </tr>
+	                            <tr>
+	                                <td><a href="@THIRD_PARTY@" target="_blank"><img
+	                                        src="images/ome_source_code.png"
+	                                        alt="Zipped Third Party Source Code" /></a></td>
+	                                <td align="center">@THIRD_PARTY_SIZE@</td>
+	                                <td>@THIRD_PARTY_BASE@</td>
+	                                <td align="center">@THIRD_PARTY_MD5@ (<a
+	                                        href="@SOURCE_CODE@.md5">MD5</a>)</td>
+	                            </tr>
+	                        </tbody>
+	                    </table>
+	                </div>
+                </div>
+            </div><!-- /.entry-content -->
+
+            <!-- OME Footer - Start -->
+            <div class="visualClear" id="clear-space-before-footer"
+                ><!-- --></div>
+            <div id="portal-footer">
+                <p>
+                    <acronym title="Copyright">&copy;</acronym> 2000-2014
+                    University of Dundee &amp; Open Microscopy Environment. <a
+                        href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
+                        >Creative Commons Attribution 3.0 Unported License</a>
+                </p>
+                <p> OME source code is available under the <a
+                        href="http://www.openmicroscopy.org/site/about/licensing"
+                        >GNU General public license</a> or through commercial
+                    license from <a
+                        href="http://www.openmicroscopy.org/site/about/development-teams/glencoe-software"
+                        >Glencoe Software</a>
+                </p>
+            </div>
+            <div class="visualClear">
+                <!-- OME Footer - END -->
+            </div>
+        </div>
+    </body>
+</html>

--- a/ice_downloads.html
+++ b/ice_downloads.html
@@ -56,7 +56,8 @@
                 <p>
                     <strong><a href="#win">Windows downloads</a>
 	                        &nbsp;&nbsp;|&nbsp;&nbsp;
-	                        <a href="#code">Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;
+	                        <a href="#code">Source code</a>
+	                        &nbsp;&nbsp;|&nbsp;&nbsp;
                     </strong></p>
                 <h2><a name="ice" id="ice"></a>Ice downloads for Windows</h2>
                 <div class="alt-table">
@@ -86,7 +87,7 @@
                         </tbody>
                     </table>
                 </div>    
-				<h2><a name="code" id="code"></a>Checking out the code</h2>
+				<h2><a name="code" id="code"></a>Source code</h2>
 	                <div class="alt-table">
 	                    <table width="800" border="0" cellpadding="5" summary="OMERO Code">
 	                        <tbody>

--- a/ice_downloads.html
+++ b/ice_downloads.html
@@ -77,7 +77,7 @@
                                     >MD5</a>)</td>
                             </tr>
                             <tr>
-                                <td><a href="@ICE_X86_WIN@">32-bit Ice for Windows x86 with 32-bit Python 2.7;</a></td>
+                                <td><a href="@ICE_X86_WIN@">32-bit Ice for Windows x86 with 32-bit Python 2.7</a></td>
                                 <td align="center">@ICE_X86_WIN_SIZE@</td>
                                 <td align="center">@ICE_X86_WIN_MD5@ (<a
                                         href="@ICE_X86_WIN@.md5"

--- a/icegen.py
+++ b/icegen.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+import os
+import sys
+import datetime
+import fileinput
+
+from doc_generator import find_pkg, repl_all
+
+fingerprint_url = "http://hudson.openmicroscopy.org.uk/fingerprint"
+MD5s = []
+
+
+def usage():
+    print "gen.py version build [build_ice34]"
+    sys.exit(1)
+
+try:
+    version = sys.argv[1]
+    build = sys.argv[2]
+except:
+    usage()
+
+repl = {"@VERSION@": version,
+        "@MONTHYEAR@": datetime.datetime.now().strftime("%b %Y")}
+
+# Read major version from input version
+import re
+split_version = re.split("^([0-9]+)\.([0-9]+)\.([0-9]+)(.*?)$", version)
+major_version = int(split_version[1])
+
+RSYNC_PATH = os.environ.get('RSYNC_PATH', '/ome/data_repo/public/')
+PREFIX = os.environ.get('PREFIX', 'ice')
+ICE_RSYNC_PATH = '%s/%s/%s/' % (RSYNC_PATH, PREFIX, version)
+
+for x, y in (
+        ("ICE_X64_WIN", "Ice-@VERSION@-win-x64-Release.zip"),
+        ("ICE_X86_WIN", "Ice-@VERSION@-win-x64-Release.zip"),
+        ("SOURCE_CODE", "Ice-@VERSION@.zip"),
+        ("THIRD_PARTY", "ThirdParty-Sources-@VERSION@-1.zip"),
+        ):
+
+    find_pkg(repl, fingerprint_url, ICE_RSYNC_PATH, x, y, MD5s)
+
+
+for line in fileinput.input(["ice_downloads.html"]):
+    print repl_all(repl, line, check_http=True),

--- a/icegen.py
+++ b/icegen.py
@@ -9,17 +9,16 @@ import fileinput
 
 from doc_generator import find_pkg, repl_all
 
-fingerprint_url = "http://hudson.openmicroscopy.org.uk/fingerprint"
+fingerprint_url = "http://ci.openmicroscopy.org/fingerprint"
 MD5s = []
 
 
 def usage():
-    print "gen.py version build [build_ice34]"
+    print "gen.py version"
     sys.exit(1)
 
 try:
     version = sys.argv[1]
-    build = sys.argv[2]
 except:
     usage()
 

--- a/icegen.py
+++ b/icegen.py
@@ -36,7 +36,7 @@ ICE_RSYNC_PATH = '%s/%s/%s/' % (RSYNC_PATH, PREFIX, version)
 
 for x, y in (
         ("ICE_X64_WIN", "Ice-@VERSION@-win-x64-Release.zip"),
-        ("ICE_X86_WIN", "Ice-@VERSION@-win-x84-Release.zip"),
+        ("ICE_X86_WIN", "Ice-@VERSION@-win-x86-Release.zip"),
         ("SOURCE_CODE", "Ice-@VERSION@.zip"),
         ("THIRD_PARTY", "ThirdParty-Sources-@VERSION@-1.zip"),
         ):

--- a/icegen.py
+++ b/icegen.py
@@ -36,7 +36,7 @@ ICE_RSYNC_PATH = '%s/%s/%s/' % (RSYNC_PATH, PREFIX, version)
 
 for x, y in (
         ("ICE_X64_WIN", "Ice-@VERSION@-win-x64-Release.zip"),
-        ("ICE_X86_WIN", "Ice-@VERSION@-win-x64-Release.zip"),
+        ("ICE_X86_WIN", "Ice-@VERSION@-win-x84-Release.zip"),
         ("SOURCE_CODE", "Ice-@VERSION@.zip"),
         ("THIRD_PARTY", "ThirdParty-Sources-@VERSION@-1.zip"),
         ):


### PR DESCRIPTION
This is the same as gh-108 but rebased onto develop.

---

This PR adds a downloads page for the custom Windows Ice packages. The build can be tested on `necromancer` with

```
RELEASE=3.5.1 make ice
```

The output of this page is manually deployed to http://downloads.openmicroscopy.org/ice/3.5.1/
