### PR TITLE
Announcement url typo (rebased onto develop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ generation:
   modules.
 
 - for OMERO, OMERO.figure, OMERO.searcher and OMERO.webtagging,
-  `ANNOUCEMENT_URL` specifies the URL of the announcement post to be used in
+  `ANNOUNCEMENT_URL` specifies the URL of the announcement post to be used in
   the downloads page.
 
 - for OMERO, `MILESTONE` is the name of the Trac milestone associated with the

--- a/figure_downloads.html
+++ b/figure_downloads.html
@@ -57,7 +57,7 @@
                 <ul>
                     <li>
                         <p>Information on this release of OMERO.figure is in the
-                                <a href="@ANNOUCEMENT_URL@">release
+                                <a href="@ANNOUNCEMENT_URL@">release
                                 announcement</a>. </p>
                     </li>
 

--- a/figuregen.py
+++ b/figuregen.py
@@ -30,7 +30,7 @@ PREFIX = os.environ.get('PREFIX', 'figure')
 FIGURE_RSYNC_PATH = '%s/%s/%s/' % (RSYNC_PATH, PREFIX, version)
 
 forum_url = "https://www.openmicroscopy.org/community/viewforum.php?f=11"
-repl["@ANNOUCEMENT_URL@"] = os.environ.get('ANNOUCEMENT_URL', forum_url)
+repl["@ANNOUNCEMENT_URL@"] = os.environ.get('ANNOUNCEMENT_URL', forum_url)
 
 for x, y in (
         ("FIGURE", "figure-@VERSION@.zip"),

--- a/gen.py
+++ b/gen.py
@@ -61,7 +61,7 @@ PREFIX = os.environ.get('PREFIX', 'omero')
 OMERO_RSYNC_PATH = '%s/%s/%s/' % (RSYNC_PATH, PREFIX, version)
 
 forum_url = "https://www.openmicroscopy.org/community/viewforum.php?f=11"
-repl["@ANNOUCEMENT_URL@"] = os.environ.get('ANNOUCEMENT_URL', forum_url)
+repl["@ANNOUNCEMENT_URL@"] = os.environ.get('ANNOUNCEMENT_URL', forum_url)
 repl["@MILESTONE@"] = os.environ.get('MILESTONE', "OMERO-%s" % version)
 
 for x, y in (

--- a/omero_downloads.html
+++ b/omero_downloads.html
@@ -71,7 +71,7 @@
                 <ul>
                     <li>
                         <p>Information on this release of OMERO is in the <a
-                                href="@ANNOUCEMENT_URL@">release
+                                href="@ANNOUNCEMENT_URL@">release
                                 announcement</a></p>
                     </li>
 

--- a/searchergen.py
+++ b/searchergen.py
@@ -36,7 +36,7 @@ PREFIX = os.environ.get('PREFIX', 'searcher')
 SEARCHER_RSYNC_PATH = '%s/%s/%s/' % (RSYNC_PATH, PREFIX, version)
 
 forum_url = "https://www.openmicroscopy.org/community/viewforum.php?f=11"
-repl["@ANNOUCEMENT_URL@"] = os.environ.get('ANNOUCEMENT_URL', forum_url)
+repl["@ANNOUNCEMENT_URL@"] = os.environ.get('ANNOUNCEMENT_URL', forum_url)
 
 for x, y in (
         ("SEARCHER", "artifacts/omero_searcher-@VERSION@-b@BUILDNUM@.tar.gz"),

--- a/webtagging_downloads.html
+++ b/webtagging_downloads.html
@@ -57,7 +57,7 @@
                 <ul>
                     <li>
                         <p>Information on this release of OMERO.webtagging is in
-                            the <a href="@ANNOUCEMENT_URL@">release
+                            the <a href="@ANNOUNCEMENT_URL@">release
                                 announcement</a>. </p>
                     </li>
 

--- a/webtagginggen.py
+++ b/webtagginggen.py
@@ -30,7 +30,7 @@ PREFIX = os.environ.get('PREFIX', 'webtagging')
 WEBTAGGING_RSYNC_PATH = '%s/%s/%s/' % (RSYNC_PATH, PREFIX, version)
 
 forum_url = "https://www.openmicroscopy.org/community/viewforum.php?f=11"
-repl["@ANNOUCEMENT_URL@"] = os.environ.get('ANNOUCEMENT_URL', forum_url)
+repl["@ANNOUNCEMENT_URL@"] = os.environ.get('ANNOUNCEMENT_URL', forum_url)
 
 for x, y in (
         ("WEBTAGGING", "webtagging-@VERSION@.zip"),


### PR DESCRIPTION
This is the same as gh-114 but rebased onto develop.

---

Reported by @hflynn in #110, this PR should fix the name of the envvar. All the following release jobs have been updated accordingly:
- [X] OMERO-5.1-release
- [X] OMERO-5.1-release-downloads
