### PR TITLE
Remove trailing -1 from third party sources (rebased onto develop)

### DIFF
--- a/icegen.py
+++ b/icegen.py
@@ -33,7 +33,7 @@ for x, y in (
         ("ICE_X64_WIN", "Ice-@VERSION@-win-x64-Release.zip"),
         ("ICE_X86_WIN", "Ice-@VERSION@-win-x86-Release.zip"),
         ("SOURCE_CODE", "Ice-@VERSION@.zip"),
-        ("THIRD_PARTY", "ThirdParty-Sources-@VERSION@-1.zip"),
+        ("THIRD_PARTY", "ThirdParty-Sources-@VERSION@.zip"),
         ):
 
     find_pkg(repl, fingerprint_url, ICE_RSYNC_PATH, x, y, MD5s)


### PR DESCRIPTION
This is the same as gh-116 but rebased onto develop.

---

Necessary fix for the release of http://downloads.openmicroscopy.org/ice/3.5.1-2/
/cc @rleigh-dundee
