### PR TITLE
Remove OMERO.py Ice 3.3 downloads

### DIFF
--- a/gen.py
+++ b/gen.py
@@ -77,7 +77,6 @@ for x, y in (
          "artifacts/OMERO.matlab-@VERSION@-ice35-@BUILD@.zip"),
         ("SERVER34", "artifacts/OMERO.server-@VERSION@-ice34-@BUILD@.zip"),
         ("SERVER35", "artifacts/OMERO.server-@VERSION@-ice35-@BUILD@.zip"),
-        ("PYTHON33", "artifacts/OMERO.py-@VERSION@-ice33-@BUILD@.zip"),
         ("PYTHON34", "artifacts/OMERO.py-@VERSION@-ice34-@BUILD@.zip"),
         ("PYTHON35", "artifacts/OMERO.py-@VERSION@-ice35-@BUILD@.zip"),
         ("DOCS", "artifacts/OMERO.docs-@VERSION@-ice34-@BUILD@.zip"),

--- a/omero_downloads.html
+++ b/omero_downloads.html
@@ -370,16 +370,6 @@
                                 <th width="122">Checksum</th>
                             </tr>
                             <tr>
-                                <td><a href="@PYTHON33@"><img
-                                        src="images/python_3_3.png"
-                                        alt="Ice 3.3 Python Download"
-                                     /></a></td>
-                                <td align="center">@PYTHON33_SIZE@</td>
-                                <td>@PYTHON33_BASE@</td>
-                                <td align="center">@PYTHON33_MD5@ (<a
-                                        href="@PYTHON33@.md5">MD5</a>)</td>
-                            </tr>
-                            <tr>
                                 <td><a href="@PYTHON34@"><img
                                         src="images/python_3_4.png"
                                         alt="Ice 3.4 Python Download"


### PR DESCRIPTION
See http://ci.openmicroscopy.org/view/Release/job/OMERO-5.1-release-downloads/9/console

--no-rebase
