### PR TITLE
Remove OMERO 4.0 versions from FLIMfit downloads page. (rebased onto develop)

### DIFF
--- a/flimfit_downloads.html
+++ b/flimfit_downloads.html
@@ -63,7 +63,7 @@
                     <li>
                         <p>Please note that this version of FLIMfit is compatible
                         with OMERO 5.0 servers. If you require compatibilty with
-                        an OMERO 4.0 server, earlier versions are available from
+                        an OMERO 4.4 server, earlier versions are available from
                         the main <a
                         href="http://downloads.openmicroscopy.org/flimfit/?C=M;O=D"
                             >downloads folder</a>. </p>

--- a/flimfit_downloads.html
+++ b/flimfit_downloads.html
@@ -62,7 +62,7 @@
                 <ul>
                     <li>
                         <p>Please note that this version of FLIMfit is compatible
-                        with OMERO 5.0 servers. If you require compatibilty with
+                        with OMERO 5.0 servers. If you require compatibility with
                         an OMERO 4.4 server, earlier versions are available from
                         the main <a
                         href="http://downloads.openmicroscopy.org/flimfit/?C=M;O=D"
@@ -78,7 +78,8 @@
                         you do not, or are in any doubt, please also
                         download the MCR for your platform <a href="#mcr">
                             below</a>. The Windows Installer will
-                        automatically install the MCR. </p>
+                        automatically install the MCR.
+                        The link below to the Windows MCR is provided only in case of problems.  </p>
                     </li>
 
                     <li>

--- a/flimfit_downloads.html
+++ b/flimfit_downloads.html
@@ -54,26 +54,31 @@
             <div class="entry-content" style="margin-left:20px;">
                 <h2>FLIMfit @VERSION@ Downloads</h2>
                 <p>
-                    <strong><a href="#flimfit_50">OMERO
-                            5.0</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
-                            href="#flimfit_44">OMERO
-                            4.4</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
+                    <strong><a href="#flimfit_50">FLIMfit</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
                             href="#mcr">MCR</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
                             href="#code">Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
                             href="#previous">Previous versions</a>
                     </strong></p>
                 <ul>
                     <li>
+                        <p>Please note that this version of FLIMfit is compatible
+                        with OMERO 5.0 servers. If you require compatibilty with
+                        an OMERO 4.0 server, earlier versions are available from
+                        the main <a
+                        href="http://downloads.openmicroscopy.org/flimfit/?C=M;O=D"
+                            >downloads folder</a>. </p>
+                    </li>
+                    <li>
                         <p>Mac users, please note that in order to run FLIMfit
-                            you will need the correct MCR (MATLAB Compiler
-                            Runtime) installed on your system (currently
-                            2013b, v8.2) which enables the execution of
-                            compiled MATLAB applications or components on
-                            computers that do not have MATLAB installed. If
-                            you do not, or are in any doubt, please also
-                            download the MCR for your platform <a href="#mcr">
+                        you will need the correct MCR (MATLAB Compiler
+                        Runtime) installed on your system (currently
+                        2013b, v8.2) which enables the execution of
+                        compiled MATLAB applications or components on
+                        computers that do not have MATLAB installed. If
+                        you do not, or are in any doubt, please also
+                        download the MCR for your platform <a href="#mcr">
                             below</a>. The Windows Installer will
-                            automatically install the MCR. </p>
+                        automatically install the MCR. </p>
                     </li>
 
                     <li>
@@ -93,11 +98,6 @@
                                 href="http://www.gnu.org/copyleft/gpl.html">GNU
                                 General Public License</a> for more details.
                         </p>
-                    </li>
-                    <li>
-                        <p>Users who intend to use FLIMfit without OMERO can
-                            download either version (for 4.4.x or 5.0.x) as
-                            there will be no difference in stand-alone mode.</p>
                     </li>
                 </ul>
                 <h2><a name="flimfit_50" id="flimfit_50"></a>FLIMfit downloads
@@ -136,42 +136,7 @@
                         </tbody>
                     </table>
                 </div>
-                <h2><a name="flimfit_44" id="flimfit_44"></a>FLIMfit downloads
-                    for OMERO 4.4.x</h2>
-                <div class="alt-table">
-                    <table width="800" border="0" cellpadding="5" summary="FLIMfit for OMERO 4.4.x Downloads">
-                        <tbody>
-                            <tr>
-                                <th width="269">Clients</th>
-                                <th width="85">Size</th>
-                                <th width="271">File Name</th>
-                                <th width="125">Checksum</th>
-                            </tr>
-                            <tr>
-                                <td><a href="@FLIMFIT_44_MAC@"><img
-                                        src="images/flimfit_mac.png"
-                                        alt="Mac OS X Client Download"
-                                     /></a></td>
-                                <td align="center">@FLIMFIT_44_MAC_SIZE@</td>
-                                <td>@FLIMFIT_44_MAC_BASE@</td>
-                                <td align="center">@FLIMFIT_44_MAC_MD5@ (<a
-                                        href="@FLIMFIT_44_MAC@.md5"
-                                    >MD5</a>)</td>
-                            </tr>
-                            <tr>
-                                <td><a href="@FLIMFIT_44_WIN@"><img
-                                        src="images/flimfit_win.png"
-                                        alt="Windows Client Download"
-                                     /></a></td>
-                                <td align="center">@FLIMFIT_44_WIN_SIZE@</td>
-                                <td>@FLIMFIT_44_WIN_BASE@</td>
-                                <td align="center">@FLIMFIT_44_WIN_MD5@ (<a
-                                        href="@FLIMFIT_44_WIN@.md5"
-                                    >MD5</a>)</td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
+                
                 <h2><a name="mcr" id="mcr"></a>MCR downloads</h2>
                 <div class="alt-table">
                     <table width="269" border="0" cellpadding="5" summary="MCR Downloads">

--- a/flimfitgen.py
+++ b/flimfitgen.py
@@ -39,8 +39,6 @@ repl["@MCR_MAC@"] = "http://www.mathworks.com/supportfiles/downloads/R2013b" \
 for x, y in (
         ("FLIMFIT_50_WIN", "artifacts/FLIMfit_@VERSION@_OME_5.0_x64.zip"),
         ("FLIMFIT_50_MAC", "artifacts/FLIMfit_@VERSION@_OME_5.0_MACI64.zip"),
-        ("FLIMFIT_44_WIN", "artifacts/FLIMfit_@VERSION@_OME_4.4_x64.zip"),
-        ("FLIMFIT_44_MAC", "artifacts/FLIMfit_@VERSION@_OME_4.4_MACI64.zip"),
         ):
 
     find_pkg(repl, fingerprint_url, FLIMFIT_RSYNC_PATH, x, y, MD5s)


### PR DESCRIPTION
This is the same as gh-121 but rebased onto develop.

---

Remove OMERO 4.0 versions from FLIMfit downloads page.
