### PR TITLE
Modify gen.py to use new tag prefix

### DIFF
--- a/gen.py
+++ b/gen.py
@@ -44,7 +44,7 @@ repo2 = gh.get_user(scc).get_repo(ome)
 for repo in (repo1, repo2):
     found = False
     for tag in repo.get_tags():
-        if tag.name == ("v.%s" % version):
+        if tag.name == ("v%s" % version):
             found = True
             break
     if found:


### PR DESCRIPTION
This PR should allow the OMERO downloads page to cope with the new tag prefix `v` starting from `5.1.0-m1`

--no-rebase
