### PR TITLE
Make doc links incl. minor version in URL

### DIFF
--- a/bfgen.py
+++ b/bfgen.py
@@ -29,10 +29,11 @@ repl = {"@VERSION@": version,
 
 MD5s = []
 
-# Read major version from input version
+# Read major and minor version from input version
 import re
 split_version = re.split("^([0-9]+)\.([0-9]+)\.([0-9]+)(.*?)$", version)
 major_version = int(split_version[1])
+minor_version = int(split_version[2])
 
 # For calculating tags
 import github
@@ -55,8 +56,8 @@ for repo in (repo1, repo2):
 
 repl["@TAG_URL@"] = repo.html_url + '/tree/' + tag.name
 repl["@DOC_URL@"] = \
-    "http://www.openmicroscopy.org/site/support/bio-formats%s" \
-    % major_version
+    "http://www.openmicroscopy.org/site/support/bio-formats%s.%s" \
+    % (major_version, minor_version)
 
 RSYNC_PATH = os.environ.get('RSYNC_PATH', '/ome/data_repo/public/')
 PREFIX = os.environ.get('PREFIX', 'bio-formats')

--- a/gen.py
+++ b/gen.py
@@ -27,10 +27,11 @@ repl = {"@VERSION@": version,
         "@BUILD@": build,
         "@MONTHYEAR@": datetime.datetime.now().strftime("%b %Y")}
 
-# Read major version from input version
+# Read major and minor version from input version
 import re
 split_version = re.split("^([0-9]+)\.([0-9]+)\.([0-9]+)(.*?)$", version)
 major_version = int(split_version[1])
+minor_version = int(split_version[2])
 
 # For calculating tags
 import github
@@ -51,8 +52,8 @@ for repo in (repo1, repo2):
         break
 
 repl["@TAG_URL@"] = repo.html_url + '/tree/' + tag.name
-repl["@DOC_URL@"] = "http://www.openmicroscopy.org/site/support/omero%s" \
-    % major_version
+repl["@DOC_URL@"] = "http://www.openmicroscopy.org/site/support/omero%s.%s" \
+    % (major_version, minor_version)
 repl["@HELP_URL@"] = "http://help.openmicroscopy.org/getting-started-%s.html"\
     % major_version
 


### PR DESCRIPTION
Doc links need to be 5.1 in the downloads pages for the 5.1.0-m1 internal release and 5.0 for the other docs once we release a full 5.1.0 version (as /support/omero5/ and /support/bio-formats5/ will both be redirected to the 5.1 docs once we release publicly). This updates doc links on the OMERO and BF download pages.

To be rebased to dev_5_0 once the 5.0 redirects are in place cc @qidane
