### PR TITLE
Fix link to Bio-Formats C++ reference documentation page

### DIFF
--- a/bf_downloads.html
+++ b/bf_downloads.html
@@ -243,7 +243,7 @@
                 <ul>
                     <li>
                         <p>Documentation on how to build Bio-Formats C++ from source  is available to read on the web <a
-                                href="@DOC_URL@/developers/buildBF-CPP.html">here</a>.</p>
+                                href="@DOC_URL@/developers/cpp.html">here</a>.</p>
                     </li>
                     <li>
                         <p>The Bio-Formats C++ Doxygen documentation is available


### PR DESCRIPTION
See https://github.com/openmicroscopy/ome-release/pull/124#issuecomment-52478169

--no-rebase
