### PR TITLE
Remove daily artifact URLs from the downloads page

### DIFF
--- a/bf_downloads.html
+++ b/bf_downloads.html
@@ -260,18 +260,15 @@
                                 <th width="180">Project</th>
                                 <th width="150">@VERSION@</th>
                                 <th width="150">Latest build</th>
-                                <th width="150">Daily build</th>
                             </tr>
                             <tr>
-                                <th colspan="4">Packages</th>
+                                <th colspan="3">Packages</th>
                             </tr>
                             <tr>
                                 <td>Bio-Formats package</td>
                                 <td><a href="@bioformats_package.jar@"
                                         >bioformats_package.jar</a></td>
                                 <td><a href="@LATEST_bioformats_package.jar@"
-                                        >bioformats_package.jar</a></td>
-                                <td><a href="@DAILY_bioformats_package.jar@"
                                         >bioformats_package.jar</a></td>
                             </tr>
                             <tr>
@@ -280,19 +277,15 @@
                                         >loci_tools.jar</a></td>
                                 <td><a href="@LATEST_loci_tools.jar@"
                                         >loci_tools.jar</a></td>
-                                <td><a href="@DAILY_loci_tools.jar@"
-                                        >loci_tools.jar</a></td>
                             </tr>
                             <tr>
-                                <th colspan="4">Core</th>
+                                <th colspan="3">Core</th>
                             </tr>
                             <tr>
                                 <td>Bio-Formats API library</td>
                                 <td><a href="@formats-api.jar@"
                                         >formats-api.jar</a></td>
                                 <td><a href="@LATEST_formats-api.jar@"
-                                        >formats-api.jar</a></td>
-                                <td><a href="@DAILY_formats-api.jar@"
                                         >formats-api.jar</a></td>
                             </tr>
                             <tr>
@@ -301,16 +294,12 @@
                                         >formats-bsd.jar</a></td>
                                 <td><a href="@LATEST_formats-bsd.jar@"
                                         >formats-bsd.jar</a></td>
-                                <td><a href="@DAILY_formats-bsd.jar@"
-                                        >formats-bsd.jar</a></td>
                             </tr>
                             <tr>
                                 <td>Bio-Formats Common library</td>
                                 <td><a href="@formats-common.jar@"
                                         >formats-common.jar</a></td>
                                 <td><a href="@LATEST_formats-common.jar@"
-                                        >formats-common.jar</a></td>
-                                <td><a href="@DAILY_formats-common.jar@"
                                         >formats-common.jar</a></td>
                             </tr>
                             <tr>
@@ -319,8 +308,6 @@
                                         >formats-gpl.jar</a></td>
                                 <td><a href="@LATEST_formats-gpl.jar@"
                                         >formats-gpl.jar</a></td>
-                                <td><a href="@DAILY_formats-gpl.jar@"
-                                        >formats-gpl.jar</a></td>
                             </tr>
                             <tr>
                                 <td>Bio-Formats BSD Test library</td>
@@ -328,15 +315,11 @@
                                         >formats-bsd-test.jar</a></td>
                                 <td><a href="@LATEST_formats-bsd-test.jar@"
                                         >formats-bsd-test.jar</a></td>
-                                <td><a href="@DAILY_formats-bsd-test.jar@"
-                                        >formats-bsd-test.jar</a></td>
                             </tr>
                             <tr>
                                 <td>OME-XML Java library</td>
                                 <td><a href="@ome-xml.jar@">ome-xml.jar</a></td>
                                 <td><a href="@LATEST_ome-xml.jar@"
-                                        >ome-xml.jar</a></td>
-                                <td><a href="@DAILY_ome-xml.jar@"
                                         >ome-xml.jar</a></td>
                             </tr>
                             <tr>
@@ -345,8 +328,6 @@
                                         >specification.jar</a></td>
                                 <td><a href="@LATEST_specification.jar@"
                                         >specification.jar</a></td>
-                                <td><a href="@DAILY_specification.jar@"
-                                        >specification.jar</a></td>
                             </tr>
                             <tr>
                                 <td>Bio-Formats Plugins for ImageJ</td>
@@ -354,15 +335,11 @@
                                         >bio-formats_plugins.jar</a></td>
                                 <td><a href="@LATEST_bio-formats_plugins.jar@"
                                         >bio-formats_plugins.jar</a></td>
-                                <td><a href="@DAILY_bio-formats_plugins.jar@"
-                                        >bio-formats_plugins.jar</a></td>
                             </tr>
                             <tr>
                                 <td>Metakit</td>
                                 <td><a href="@metakit.jar@">metakit.jar</a></td>
                                 <td><a href="@LATEST_metakit.jar@"
-                                        >metakit.jar</a></td>
-                                <td><a href="@DAILY_metakit.jar@"
                                         >metakit.jar</a></td>
                             </tr>
                             <tr>
@@ -373,20 +350,15 @@
                                 <td><a
                                         href="@LATEST_bio-formats-testing-framework.jar@"
                                         >bio-formats-testing-framework.jar</a></td>
-                                <td><a
-                                        href="@DAILY_bio-formats-testing-framework.jar@"
-                                        >bio-formats-testing-framework.jar</a></td>
                             </tr>
                             <tr>
-                                <th align="center" colspan="4">Forks</th>
+                                <th align="center" colspan="3">Forks</th>
                             </tr>
                             <tr>
                                 <td>JAI Image I/O Tools</td>
                                 <td><a href="@jai_imageio.jar@"
                                         >jai_imageio.jar</a></td>
                                 <td><a href="@LATEST_jai_imageio.jar@"
-                                        >jai_imageio.jar</a></td>
-                                <td><a href="@DAILY_jai_imageio.jar@"
                                         >jai_imageio.jar</a></td>
                             </tr>
                             <tr>
@@ -395,15 +367,11 @@
                                         >mdbtools-java.jar</a></td>
                                 <td><a href="@LATEST_mdbtools-java.jar@"
                                         >mdbtools-java.jar</a></td>
-                                <td><a href="@DAILY_mdbtools-java.jar@"
-                                        >mdbtools-java.jar</a></td>
                             </tr>
                             <tr>
                                 <td>Apache Jakarta POI</td>
                                 <td><a href="@ome-poi.jar@">ome-poi.jar</a></td>
                                 <td><a href="@LATEST_ome-poi.jar@"
-                                        >ome-poi.jar</a></td>
-                                <td><a href="@DAILY_ome-poi.jar@"
                                         >ome-poi.jar</a></td>
                             </tr>
                             <tr>
@@ -412,19 +380,15 @@
                                     >turbojpeg.jar</a></td>
                                 <td><a href="@LATEST_turbojpeg.jar@"
                                         >turbojpeg.jar</a></td>
-                                <td><a href="@DAILY_turbojpeg.jar@"
-                                        >turbojpeg.jar</a></td>
                             </tr>
                             <tr>
-                                <th align="center" colspan="4">Stubs</th>
+                                <th align="center" colspan="3">Stubs</th>
                             </tr>
                             <tr>
                                 <td>Luratech LuraWave stubs</td>
                                 <td><a href="@lwf-stubs.jar@"
                                     >lwf-stubs.jar</a></td>
                                 <td><a href="@LATEST_lwf-stubs.jar@"
-                                        >lwf-stubs.jar</a></td>
-                                <td><a href="@DAILY_lwf-stubs.jar@"
                                         >lwf-stubs.jar</a></td>
                             </tr>
                         </tbody>

--- a/bfgen.py
+++ b/bfgen.py
@@ -9,8 +9,6 @@ import fileinput
 from doc_generator import find_pkg, repl_all
 
 fingerprint_url = "http://ci.openmicroscopy.org/fingerprint"
-daily_url = "http://ci.openmicroscopy.org/job/BIOFORMATS-5.1-daily/" \
-    "lastSuccessfulBuild/artifact/artifacts"
 latest_url = "http://ci.openmicroscopy.org/job/BIOFORMATS-5.1-latest/" \
     "lastSuccessfulBuild/artifact/artifacts"
 
@@ -94,7 +92,6 @@ for x, y in (
 
     find_pkg(repl, fingerprint_url, BF_RSYNC_PATH, x, y, MD5s)
 
-    repl["@DAILY_%s@" % x] = "%s/%s" % (daily_url, x)
     repl["@LATEST_%s@" % x] = "%s/%s" % (latest_url, x)
 
 for line in fileinput.input(["bf_downloads.html"]):


### PR DESCRIPTION
Remove the daily artifacts from the downloads page since the BIOFORMATS-5.1-daily job has been deprecated in favor of the BIOFORMATS-5.1-latest job /cc @melissalinkert 
--no-rebase
