### PR TITLE
Removing OMERO.editor from downloads page

### DIFF
--- a/omero_downloads.html
+++ b/omero_downloads.html
@@ -146,11 +146,9 @@
                     <li>
                         <p>Each client package includes <a
                                 href="@DOC_URL@/users/clients-overview.html#omero-insight"
-                                >OMERO.insight</a>, <a
+                                >OMERO.insight</a> and <a
                                 href="@DOC_URL@/users/clients-overview.html#omero-importer"
-                                >OMERO.importer</a> and <a
-                                href="@DOC_URL@/users/clients-overview.html#omero-editor"
-                                >OMERO.editor</a> and requires Java Version
+                                >OMERO.importer</a> and requires Java Version
                                 <strong>1.6</strong> or higher. OMERO.web is
                             part of the server package, so individual users do
                             not need to install it locally.</p>


### PR DESCRIPTION
Editor is being removed for the 5.1 release, this removes reference to it from the OMERO downloads page.

--no-rebase
