### PR TITLE
Swapping order of Mac and Win MCR downloads (rebased onto develop)

### DIFF
--- a/flimfit_downloads.html
+++ b/flimfit_downloads.html
@@ -146,15 +146,15 @@
                                 <th width="269">MCR</th>
                             </tr>
                             <tr>
-                                <td><a href="@MCR_WIN@"><img
-                                        src="images/mcr_windows.png"
-                                        alt="Windows MCR Download"
-                                     /></a></td>
-                            </tr>
-                            <tr>
                                 <td><a href="@MCR_MAC@"><img
                                         src="images/mcr_mac.png"
                                         alt="Mac OS X MCR Download"
+                                     /></a></td>
+                            </tr>
+                            <tr>
+                                <td><a href="@MCR_WIN@"><img
+                                        src="images/mcr_windows.png"
+                                        alt="Windows MCR Download"
                                      /></a></td>
                             </tr>
                         </tbody>


### PR DESCRIPTION
This is the same as gh-130 but rebased onto develop.

---

As noticed by @pwalczysko - the MCR downloads were the opposite way around to the FLIMfit downloads above, which is confusing.
