### PR TITLE
Add support fot SHA1 checksum

### DIFF
--- a/bf_downloads.html
+++ b/bf_downloads.html
@@ -108,9 +108,9 @@
                                 <td align="center"
                                     >@bioformats_package.jar_SIZE@</td>
                                 <td>@bioformats_package.jar_BASE@</td>
-                                <td align="center">@bioformats_package.jar_MD5@
-                                        (<a href="@bioformats_package.jar@.md5"
-                                        >MD5</a>)</td>
+                                <td align="center">@bioformats_package.jar_SHA1@
+                                        (<a href="@bioformats_package.jar@.sha1"
+                                        >SHA1</a>)</td>
                             </tr>
                             <tr>
                                 <td><a href="@COMMAND_LINE_TOOLS@"><img
@@ -119,9 +119,9 @@
                                 <td align="center"
                                     >@COMMAND_LINE_TOOLS_SIZE@</td>
                                 <td>@COMMAND_LINE_TOOLS_BASE@</td>
-                                <td align="center">@COMMAND_LINE_TOOLS_MD5@ (<a
-                                        href="@COMMAND_LINE_TOOLS@.md5"
-                                    >MD5</a>)</td>
+                                <td align="center">@COMMAND_LINE_TOOLS_SHA1@ (<a
+                                        href="@COMMAND_LINE_TOOLS@.sha1"
+                                    >SHA1</a>)</td>
                             </tr>
                             <tr>
                                 <td><a href="@MATLAB_TOOLS@"><img
@@ -129,8 +129,8 @@
                                         alt="MATLAB Toolbox" /></a></td>
                                 <td align="center">@MATLAB_TOOLS_SIZE@</td>
                                 <td>@MATLAB_TOOLS_BASE@</td>
-                                <td align="center">@MATLAB_TOOLS_MD5@ (<a
-                                        href="@MATLAB_TOOLS@.md5">MD5</a>)</td>
+                                <td align="center">@MATLAB_TOOLS_SHA1@ (<a
+                                        href="@MATLAB_TOOLS@.sha1">SHA1</a>)</td>
                             </tr>
                         </tbody>
                     </table>
@@ -173,7 +173,7 @@
                                 <th width="269">API Documentation</th>
                                 <th width="85">Size</th>
                                 <th width="150">File Name</th>
-                                <th width="125">MD5 Checksum</th>
+                                <th width="125">SHA1 Checksum</th>
                             </tr>
                             <tr>
                                 <td><a href="@JAVADOCS@"><img
@@ -182,8 +182,8 @@
                                      /></a></td>
                                 <td align="center">@JAVADOCS_SIZE@</td>
                                 <td>@JAVADOCS_BASE@</td>
-                                <td align="center">@JAVADOCS_MD5@ (<a
-                                        href="@JAVADOCS@.md5">MD5</a>)</td>
+                                <td align="center">@JAVADOCS_SHA1@ (<a
+                                        href="@JAVADOCS@.sha1">SHA1</a>)</td>
                             </tr>
                         </tbody>
                     </table>
@@ -203,7 +203,7 @@
                                 <th width="269">Downloads</th>
                                 <th width="85">Size</th>
                                 <th width="150">File Name</th>
-                                <th width="125">MD5 Checksum</th>
+                                <th width="125">SHA1 Checksum</th>
                             </tr>
                             <tr>
 	                           <td><a href="@SOURCE_CODE@" target="_blank"><img
@@ -211,8 +211,8 @@
                                         alt="Zipped Source Code" /></a></td>
                                 <td align="center">@SOURCE_CODE_SIZE@</td>
                                 <td>@SOURCE_CODE_BASE@</td>
-                                <td align="center">@SOURCE_CODE_MD5@ (<a
-                                        href="@SOURCE_CODE@.md5">MD5</a>)</td>
+                                <td align="center">@SOURCE_CODE_SHA1@ (<a
+                                        href="@SOURCE_CODE@.sha1">SHA1</a>)</td>
 		                     </tr>
 		                     <tr>
                                 <td><a href="@CPP_CENTOS65@"><img
@@ -221,8 +221,8 @@
                                      /></a></td>
                                 <td align="center">@CPP_CENTOS65_SIZE@</td>
                                 <td>@CPP_CENTOS65_BASE@</td>
-                                <td align="center">@CPP_CENTOS65_MD5@ (<a
-                                        href="@CPP_CENTOS65@.md5">MD5</a>)</td>
+                                <td align="center">@CPP_CENTOS65_SHA1@ (<a
+                                        href="@CPP_CENTOS65@.sha1">SHA1</a>)</td>
                              </tr>
 		                     <tr>
                                 <td><a href="@CPP_OSX108@"><img
@@ -231,8 +231,8 @@
                                      /></a></td>
                                 <td align="center">@CPP_OSX108_SIZE@</td>
                                 <td>@CPP_OSX108_BASE@</td>
-                                <td align="center">@CPP_OSX108_MD5@ (<a
-                                        href="@CPP_OSX108@.md5">MD5</a>)</td>
+                                <td align="center">@CPP_OSX108_SHA1@ (<a
+                                        href="@CPP_OSX108@.sha1">SHA1</a>)</td>
                             </tr>
 		                    <tr>
                                 <td><a href="@CPP_OSX109@"><img
@@ -241,8 +241,8 @@
                                      /></a></td>
                                 <td align="center">@CPP_OSX109_SIZE@</td>
                                 <td>@CPP_OSX109_BASE@</td>
-                                <td align="center">@CPP_OSX109_MD5@ (<a
-                                        href="@CPP_OSX109@.md5">MD5</a>)</td>
+                                <td align="center">@CPP_OSX109_SHA1@ (<a
+                                        href="@CPP_OSX109@.sha1">SHA1</a>)</td>
                             </tr>
                         </tbody>
                     </table>
@@ -417,8 +417,8 @@
                                         alt="Zipped Source Code" /></a></td>
                                 <td align="center">@SOURCE_CODE_SIZE@</td>
                                 <td>@SOURCE_CODE_BASE@</td>
-                                <td align="center">@SOURCE_CODE_MD5@ (<a
-                                        href="@SOURCE_CODE@.md5">MD5</a>)</td>
+                                <td align="center">@SOURCE_CODE_SHA1@ (<a
+                                        href="@SOURCE_CODE@.sha1">SHA1</a>)</td>
                             </tr>
                         </tbody>
                     </table>

--- a/bf_downloads.html
+++ b/bf_downloads.html
@@ -234,16 +234,6 @@
                                 <td align="center">@CPP_OSX108_SHA1@ (<a
                                         href="@CPP_OSX108@.sha1">SHA1</a>)</td>
                             </tr>
-		                    <tr>
-                                <td><a href="@CPP_OSX109@"><img
-                                        src="images/bf_c++_mac_10_9.png"
-                                        alt="OS X 10.9 C++ binaries"
-                                     /></a></td>
-                                <td align="center">@CPP_OSX109_SIZE@</td>
-                                <td>@CPP_OSX109_BASE@</td>
-                                <td align="center">@CPP_OSX109_SHA1@ (<a
-                                        href="@CPP_OSX109@.sha1">SHA1</a>)</td>
-                            </tr>
                         </tbody>
                     </table>
                 </div>

--- a/bfgen.py
+++ b/bfgen.py
@@ -65,7 +65,6 @@ for x, y in (
         ("JAVADOCS", "artifacts/bio-formats-javadocs.zip"),
         ("SOURCE_CODE", "artifacts/bioformats-@VERSION@.zip"),
         ("CPP_OSX108", "artifacts/bioformats-cpp-@VERSION@-MacOSX10.8.zip"),
-        ("CPP_OSX109", "artifacts/bioformats-cpp-@VERSION@-MacOSX10.9.zip"),
         ("CPP_CENTOS65",
          "artifacts/bioformats-cpp-@VERSION@-CentOS6.5-x86_64.zip"),
         ("bioformats_package.jar", "artifacts/bioformats_package.jar"),

--- a/bfgen.py
+++ b/bfgen.py
@@ -8,9 +8,8 @@ import fileinput
 
 from doc_generator import find_pkg, repl_all
 
-fingerprint_url = "http://ci.openmicroscopy.org/fingerprint"
-latest_url = "http://ci.openmicroscopy.org/job/BIOFORMATS-5.1-latest/" \
-    "lastSuccessfulBuild/artifact/artifacts"
+latest_url = ("http://ci.openmicroscopy.org/job/BIOFORMATS-5.1-latest/"
+              "lastSuccessfulBuild/artifact/artifacts")
 
 
 def usage():
@@ -24,8 +23,6 @@ except:
 
 repl = {"@VERSION@": version,
         "@MONTHYEAR@": datetime.datetime.now().strftime("%b %Y")}
-
-MD5s = []
 
 # Read major and minor version from input version
 import re
@@ -91,7 +88,7 @@ for x, y in (
         ("turbojpeg.jar", "artifacts/turbojpeg.jar"),
         ):
 
-    find_pkg(repl, fingerprint_url, BF_RSYNC_PATH, x, y, MD5s)
+    find_pkg(repl, BF_RSYNC_PATH, x, y)
 
     repl["@LATEST_%s@" % x] = "%s/%s" % (latest_url, x)
 

--- a/doc_generator.py
+++ b/doc_generator.py
@@ -90,7 +90,7 @@ def get_hash(filename, type):
 
     read_hash = None
     with open(filename + '.' + type, "r") as f:
-        read_hash = f.reader()
+        read_hash = f.read()
     return read_hash
 
 

--- a/doc_generator.py
+++ b/doc_generator.py
@@ -4,9 +4,11 @@
 
 import os
 import glob
-import hashlib
 
 from urllib2 import build_opener, Request
+
+FINGERPRINT_URL = os.environ.get(
+    'FINGERPRINT_URL', "http://ci.openmicroscopy.org/fingerprint")
 
 
 class HeadRequest(Request):
@@ -120,7 +122,7 @@ def humansize(nbytes):
     return '%s %s' % (f, suffixes[i])
 
 
-def find_pkg(repl, fingerprint_url, snapshot_path, name, path, ignore_md5=[]):
+def find_pkg(repl, snapshot_path, name, path, ignore_md5=[]):
     """
     Mutates the repl argument
     """
@@ -133,7 +135,7 @@ def find_pkg(repl, fingerprint_url, snapshot_path, name, path, ignore_md5=[]):
     md5_hash = get_hash(path, 'md5')
     sha1_hash = get_hash(path, 'sha1')
     if "SKIP_MD5" not in os.environ and md5_hash not in ignore_md5:
-        furl = "/".join([fingerprint_url, md5_hash, "api", "xml"])
+        furl = "/".join([FINGERPRINT_URL, md5_hash, "api", "xml"])
         if not check_url(furl):
             raise Exception("Error accessing %s for %s" % (furl, path))
     repl["@%s@" % name] = "./" + path[len(snapshot_path):]

--- a/figure_downloads.html
+++ b/figure_downloads.html
@@ -91,8 +91,8 @@
                                         alt="OMERO.figure Download" /></a></td>
                                 <td align="center">@FIGURE_SIZE@</td>
                                 <td>@FIGURE_BASE@</td>
-                                <td align="center">@FIGURE_MD5@ (<a
-                                        href="@FIGURE@.md5">MD5</a>)</td>
+                                <td align="center">@FIGURE_SHA1@ (<a
+                                        href="@FIGURE@.sha1">SHA1</a>)</td>
                             </tr>
                         </tbody>
                     </table>

--- a/figuregen.py
+++ b/figuregen.py
@@ -9,9 +9,6 @@ import fileinput
 
 from doc_generator import find_pkg, repl_all
 
-fingerprint_url = "http://ci.openmicroscopy.org/fingerprint"
-MD5s = []
-
 
 def usage():
     print "figuregen.py version"
@@ -36,7 +33,7 @@ for x, y in (
         ("FIGURE", "figure-@VERSION@.zip"),
         ):
 
-    find_pkg(repl, fingerprint_url, FIGURE_RSYNC_PATH, x, y, MD5s)
+    find_pkg(repl, FIGURE_RSYNC_PATH, x, y)
 
 
 for line in fileinput.input(["figure_downloads.html"]):

--- a/flimfit_downloads.html
+++ b/flimfit_downloads.html
@@ -119,9 +119,9 @@
                                      /></a></td>
                                 <td align="center">@FLIMFIT_50_MAC_SIZE@</td>
                                 <td>@FLIMFIT_50_MAC_BASE@</td>
-                                <td align="center">@FLIMFIT_50_MAC_MD5@ (<a
-                                        href="@FLIMFIT_50_MAC@.md5"
-                                    >MD5</a>)</td>
+                                <td align="center">@FLIMFIT_50_MAC_SHA1@ (<a
+                                        href="@FLIMFIT_50_MAC@.sha1"
+                                    >SHA1</a>)</td>
                             </tr>
                             <tr>
                                 <td><a href="@FLIMFIT_50_WIN@"><img
@@ -130,9 +130,9 @@
                                      /></a></td>
                                 <td align="center">@FLIMFIT_50_WIN_SIZE@</td>
                                 <td>@FLIMFIT_50_WIN_BASE@</td>
-                                <td align="center">@FLIMFIT_50_WIN_MD5@ (<a
-                                        href="@FLIMFIT_50_WIN@.md5"
-                                    >MD5</a>)</td>
+                                <td align="center">@FLIMFIT_50_WIN_SHA1@ (<a
+                                        href="@FLIMFIT_50_WIN@.sha1"
+                                    >SHA1</a>)</td>
                             </tr>
                         </tbody>
                     </table>

--- a/flimfitgen.py
+++ b/flimfitgen.py
@@ -9,9 +9,6 @@ import fileinput
 
 from doc_generator import find_pkg, repl_all
 
-fingerprint_url = "http://ci.openmicroscopy.org/fingerprint"
-MD5s = []
-
 
 def usage():
     print "flimfitgen.py version"
@@ -41,7 +38,7 @@ for x, y in (
         ("FLIMFIT_50_MAC", "artifacts/FLIMfit_@VERSION@_OME_5.0_MACI64.zip"),
         ):
 
-    find_pkg(repl, fingerprint_url, FLIMFIT_RSYNC_PATH, x, y, MD5s)
+    find_pkg(repl, FLIMFIT_RSYNC_PATH, x, y)
 
 
 for line in fileinput.input(["flimfit_downloads.html"]):

--- a/gen.py
+++ b/gen.py
@@ -9,9 +9,6 @@ import fileinput
 
 from doc_generator import find_pkg, repl_all
 
-fingerprint_url = "http://ci.openmicroscopy.org/fingerprint"
-MD5s = []
-
 
 def usage():
     print "gen.py version build [build_ice34]"
@@ -87,7 +84,7 @@ for x, y in (
         ("SOURCE_CODE", "artifacts/openmicroscopy-@VERSION@.zip"),
         ):
 
-    find_pkg(repl, fingerprint_url, OMERO_RSYNC_PATH, x, y, MD5s)
+    find_pkg(repl, OMERO_RSYNC_PATH, x, y)
 
 
 for line in fileinput.input(["omero_downloads.html"]):

--- a/ice_downloads.html
+++ b/ice_downloads.html
@@ -73,16 +73,16 @@
 	                                   64-bit Ice for Windows x64 with 64-bit 
 	                                   Python 2.7</a></td>
                                 <td align="center">@ICE_X64_WIN_SIZE@</td>
-                                <td align="center">@ICE_X64_WIN_MD5@ (<a
-                                        href="@ICE_X64_WIN@.md5"
-                                    >MD5</a>)</td>
+                                <td align="center">@ICE_X64_WIN_SHA1@ (<a
+                                        href="@ICE_X64_WIN@.sha1"
+                                    >SHA1</a>)</td>
                             </tr>
                             <tr>
                                 <td><a href="@ICE_X86_WIN@">32-bit Ice for Windows x86 with 32-bit Python 2.7</a></td>
                                 <td align="center">@ICE_X86_WIN_SIZE@</td>
-                                <td align="center">@ICE_X86_WIN_MD5@ (<a
-                                        href="@ICE_X86_WIN@.md5"
-                                    >MD5</a>)</td>
+                                <td align="center">@ICE_X86_WIN_SHA1@ (<a
+                                        href="@ICE_X86_WIN@.sha1"
+                                    >SHA1</a>)</td>
                             </tr>
                         </tbody>
                     </table>
@@ -99,14 +99,14 @@
 	                            <tr>
 	                                <td><a href="@SOURCE_CODE@" target="_blank">Ice source code</a></td>
 	                                <td align="center">@SOURCE_CODE_SIZE@</td>
-	                                <td align="center">@SOURCE_CODE_MD5@ (<a
-	                                        href="@SOURCE_CODE@.md5">MD5</a>)</td>
+	                                <td align="center">@SOURCE_CODE_SHA1@ (<a
+	                                        href="@SOURCE_CODE@.sha1">SHA1</a>)</td>
 	                            </tr>
 	                            <tr>
 	                                <td><a href="@THIRD_PARTY@" target="_blank">Ice third party source code</a></td>
 	                                <td align="center">@THIRD_PARTY_SIZE@</td>
-	                                <td align="center">@THIRD_PARTY_MD5@ (<a
-	                                        href="@SOURCE_CODE@.md5">MD5</a>)</td>
+	                                <td align="center">@THIRD_PARTY_SHA1@ (<a
+	                                        href="@SOURCE_CODE@.sha1">SHA1</a>)</td>
 	                            </tr>
 	                        </tbody>
 	                    </table>

--- a/icegen.py
+++ b/icegen.py
@@ -9,9 +9,6 @@ import fileinput
 
 from doc_generator import find_pkg, repl_all
 
-fingerprint_url = "http://ci.openmicroscopy.org/fingerprint"
-MD5s = []
-
 
 def usage():
     print "gen.py version"
@@ -36,7 +33,7 @@ for x, y in (
         ("THIRD_PARTY", "ThirdParty-Sources-@VERSION@.zip"),
         ):
 
-    find_pkg(repl, fingerprint_url, ICE_RSYNC_PATH, x, y, MD5s)
+    find_pkg(repl, ICE_RSYNC_PATH, x, y)
 
 
 for line in fileinput.input(["ice_downloads.html"]):

--- a/mtools_downloads.html
+++ b/mtools_downloads.html
@@ -98,8 +98,8 @@
                                      /></a></td>
                                 <td align="center">@MTOOLS_WIN_SIZE@</td>
                                 <td>@MTOOLS_WIN_BASE@</td>
-                                <td align="center">@MTOOLS_WIN_MD5@ (<a
-                                        href="@MTOOLS_WIN@.md5">MD5</a>)</td>
+                                <td align="center">@MTOOLS_WIN_SHA1@ (<a
+                                        href="@MTOOLS_WIN@.sha1">SHA1</a>)</td>
                             </tr>
                             <tr>
                                 <td><a href="@MTOOLS_MAC@"><img
@@ -108,8 +108,8 @@
                                      /></a></td>
                                 <td align="center">@MTOOLS_MAC_SIZE@</td>
                                 <td>@MTOOLS_MAC_BASE@</td>
-                                <td align="center">@MTOOLS_MAC_MD5@ (<a
-                                        href="@MTOOLS_MAC@.md5">MD5</a>)</td>
+                                <td align="center">@MTOOLS_MAC_SHA1@ (<a
+                                        href="@MTOOLS_MAC@.sha1">SHA1</a>)</td>
                             </tr>
                         </tbody>
                     </table>

--- a/mtoolsgen.py
+++ b/mtoolsgen.py
@@ -8,8 +8,6 @@ import fileinput
 
 from doc_generator import find_pkg, repl_all
 
-fingerprint_url = "http://ci.openmicroscopy.org/fingerprint"
-
 
 def usage():
     print "mtoolsgen.py version"
@@ -23,9 +21,6 @@ except:
 repl = {"@VERSION@": version,
         "@MONTHYEAR@": datetime.datetime.now().strftime("%b %Y")}
 
-MD5s = []
-
-
 RSYNC_PATH = os.environ.get('RSYNC_PATH', '/ome/data_repo/public/')
 PREFIX = os.environ.get('PREFIX', 'mtools')
 UTRACK_RSYNC_PATH = '%s/%s/%s/' % (RSYNC_PATH, PREFIX, version)
@@ -35,7 +30,7 @@ for x, y in (
         ("MTOOLS_MAC", "OMERO.mtools_@VERSION@_mac.zip"),
         ):
 
-    find_pkg(repl, fingerprint_url, UTRACK_RSYNC_PATH, x, y, MD5s)
+    find_pkg(repl, UTRACK_RSYNC_PATH, x, y)
 
 for line in fileinput.input(["mtools_downloads.html"]):
     print repl_all(repl, line, check_http=True),

--- a/omero_downloads.html
+++ b/omero_downloads.html
@@ -124,8 +124,8 @@
                                      /></a></td>
                                 <td align="center">@WIN_CLIENTS_SIZE@</td>
                                 <td>@WIN_CLIENTS_BASE@</td>
-                                <td align="center">@WIN_CLIENTS_MD5@ (<a
-                                        href="@WIN_CLIENTS@.md5">MD5</a>)</td>
+                                <td align="center">@WIN_CLIENTS_SHA1@ (<a
+                                        href="@WIN_CLIENTS@.sha1">SHA1</a>)</td>
                             </tr>
                             <tr>
                                 <td><a href="@MAC_CLIENTS@"><img
@@ -134,8 +134,8 @@
                                      /></a></td>
                                 <td align="center">@MAC_CLIENTS_SIZE@</td>
                                 <td>@MAC_CLIENTS_BASE@</td>
-                                <td align="center">@MAC_CLIENTS_MD5@ (<a
-                                        href="@MAC_CLIENTS@.md5">MD5</a>)</td>
+                                <td align="center">@MAC_CLIENTS_SHA1@ (<a
+                                        href="@MAC_CLIENTS@.sha1">SHA1</a>)</td>
                             </tr>
                             <tr>
                                 <td><a href="@LINUX_CLIENTS@"><img
@@ -143,8 +143,8 @@
                                         alt="Linux Client Download" /></a></td>
                                 <td align="center">@LINUX_CLIENTS_SIZE@</td>
                                 <td>@LINUX_CLIENTS_BASE@</td>
-                                <td align="center">@LINUX_CLIENTS_MD5@ (<a
-                                        href="@LINUX_CLIENTS@.md5">MD5</a>)</td>
+                                <td align="center">@LINUX_CLIENTS_SHA1@ (<a
+                                        href="@LINUX_CLIENTS@.sha1">SHA1</a>)</td>
                             </tr>
                         </tbody>
                     </table>
@@ -185,8 +185,8 @@
                                      /></a></td>
                                 <td align="center">@IJ_CLIENTS_SIZE@</td>
                                 <td>@IJ_CLIENTS_BASE@</td>
-                                <td align="center">@IJ_CLIENTS_MD5@ (<a
-                                        href="@IJ_CLIENTS@.md5">MD5</a>)</td>
+                                <td align="center">@IJ_CLIENTS_SHA1@ (<a
+                                        href="@IJ_CLIENTS@.sha1">SHA1</a>)</td>
                             </tr>
                             <tr>
                                 <td><a href="@MATLAB_CLIENTS@"><img
@@ -194,9 +194,9 @@
                                         alt="Matlab Plugin Download" /></a></td>
                                 <td align="center">@MATLAB_CLIENTS_SIZE@</td>
                                 <td>@MATLAB_CLIENTS_BASE@</td>
-                                <td align="center">@MATLAB_CLIENTS_MD5@ (<a
-                                        href="@MATLAB_CLIENTS@.md5"
-                                    >MD5</a>)</td>
+                                <td align="center">@MATLAB_CLIENTS_SHA1@ (<a
+                                        href="@MATLAB_CLIENTS@.sha1"
+                                    >SHA1</a>)</td>
                             </tr>
                         </tbody>
                     </table>
@@ -251,8 +251,8 @@
                                      /></a></td>
                                 <td align="center">@SERVER34_SIZE@</td>
                                 <td>@SERVER34_BASE@</td>
-                                <td align="center">@SERVER34_MD5@ (<a
-                                        href="@SERVER34@.md5">MD5</a>)</td>
+                                <td align="center">@SERVER34_SHA1@ (<a
+                                        href="@SERVER34@.sha1">SHA1</a>)</td>
                             </tr>
                             <tr>
                                 <td><a href="@SERVER35@"><img
@@ -261,8 +261,8 @@
                                      /></a></td>
                                 <td align="center">@SERVER35_SIZE@</td>
                                 <td>@SERVER35_BASE@</td>
-                                <td align="center">@SERVER35_MD5@ (<a
-                                        href="@SERVER35@.md5">MD5</a>)</td>
+                                <td align="center">@SERVER35_SHA1@ (<a
+                                        href="@SERVER35@.sha1">SHA1</a>)</td>
                             </tr>
                         </tbody>
                     </table>
@@ -314,8 +314,8 @@
                                      /></a></td>
                                 <td align="center">@VM_SIZE@</td>
                                 <td>@VM_BASE@</td>
-                                <td align="center">@VM_MD5@ (<a href="@VM@.md5"
-                                        >MD5</a>)</td>
+                                <td align="center">@VM_SHA1@ (<a href="@VM@.sha1"
+                                        >SHA1</a>)</td>
                             </tr>
                         </tbody>
                     </table>
@@ -339,7 +339,7 @@
                                 <th width="269">API Documentation</th>
                                 <th width="92">Size</th>
                                 <th width="271">File Name</th>
-                                <th width="118">MD5 Checksum</th>
+                                <th width="118">SHA1 Checksum</th>
                             </tr>
                             <tr>
                                 <td><a href="@DOCS@"><img
@@ -348,8 +348,8 @@
                                      /></a></td>
                                 <td align="center">@DOCS_SIZE@</td>
                                 <td>@DOCS_BASE@</td>
-                                <td align="center">@DOCS_MD5@ (<a
-                                        href="@DOCS@.md5">MD5</a>)</td>
+                                <td align="center">@DOCS_SHA1@ (<a
+                                        href="@DOCS@.sha1">SHA1</a>)</td>
                             </tr>
                         </tbody>
                     </table>
@@ -382,8 +382,8 @@
                                      /></a></td>
                                 <td align="center">@PYTHON34_SIZE@</td>
                                 <td>@PYTHON34_BASE@</td>
-                                <td align="center">@PYTHON34_MD5@ (<a
-                                        href="@PYTHON34@.md5">MD5</a>)</td>
+                                <td align="center">@PYTHON34_SHA1@ (<a
+                                        href="@PYTHON34@.sha1">SHA1</a>)</td>
                             </tr>
                             <tr>
                                 <td><a href="@PYTHON35@"><img
@@ -392,8 +392,8 @@
                                      /></a></td>
                                 <td align="center">@PYTHON35_SIZE@</td>
                                 <td>@PYTHON35_BASE@</td>
-                                <td align="center">@PYTHON35_MD5@ (<a
-                                        href="@PYTHON35@.md5">MD5</a>)</td>
+                                <td align="center">@PYTHON35_SHA1@ (<a
+                                        href="@PYTHON35@.sha1">SHA1</a>)</td>
                             </tr>
                         </tbody>
                     </table>
@@ -421,8 +421,8 @@
                                      /></a></td>
                                 <td align="center">@JAVA35_SIZE@</td>
                                 <td>@JAVA35_BASE@</td>
-                                <td align="center">@JAVA35_MD5@ (<a
-                                        href="@JAVA35@.md5">MD5</a>)</td>
+                                <td align="center">@JAVA35_SHA1@ (<a
+                                        href="@JAVA35@.sha1">SHA1</a>)</td>
                             </tr>
                         </tbody>
                     </table>
@@ -443,8 +443,8 @@
                                         alt="Zipped Source Code" /></a></td>
                                 <td align="center">@SOURCE_CODE_SIZE@</td>
                                 <td>@SOURCE_CODE_BASE@</td>
-                                <td align="center">@SOURCE_CODE_MD5@ (<a
-                                        href="@SOURCE_CODE@.md5">MD5</a>)</td>
+                                <td align="center">@SOURCE_CODE_SHA1@ (<a
+                                        href="@SOURCE_CODE@.sha1">SHA1</a>)</td>
                             </tr>
                         </tbody>
                     </table>

--- a/searcher_downloads.html
+++ b/searcher_downloads.html
@@ -95,8 +95,8 @@
                                      /></a></td>
                                 <td align="center">@SEARCHER_SIZE@</td>
                                 <td>@SEARCHER_BASE@</td>
-                                <td align="center">@SEARCHER_MD5@ (<a
-                                        href="@SEARCHER@.md5">MD5</a>)</td>
+                                <td align="center">@SEARCHER_SHA1@ (<a
+                                        href="@SEARCHER@.sha1">SHA1</a>)</td>
                             </tr>
                             <tr>
                                 <td><a href="@PYSLID@"><img
@@ -104,8 +104,8 @@
                                         alt="pyslid download" /></a></td>
                                 <td align="center">@PYSLID_SIZE@</td>
                                 <td>@PYSLID_BASE@</td>
-                                <td align="center">@PYSLID_MD5@ (<a
-                                        href="@PYSLID@.md5">MD5</a>)</td>
+                                <td align="center">@PYSLID_SHA1@ (<a
+                                        href="@PYSLID@.sha1">SHA1</a>)</td>
                             </tr>
                             <tr>
                                 <td><a href="@RICERCA@"><img
@@ -113,8 +113,8 @@
                                         alt="ricerca download" /></a></td>
                                 <td align="center">@RICERCA_SIZE@</td>
                                 <td>@RICERCA_BASE@</td>
-                                <td align="center">@RICERCA_MD5@ (<a
-                                        href="@RICERCA@.md5">MD5</a>)</td>
+                                <td align="center">@RICERCA_SHA1@ (<a
+                                        href="@RICERCA@.sha1">SHA1</a>)</td>
                             </tr>
                         </tbody>
                     </table>

--- a/searchergen.py
+++ b/searchergen.py
@@ -9,9 +9,6 @@ import fileinput
 
 from doc_generator import find_pkg, repl_all
 
-fingerprint_url = "http://ci.openmicroscopy.org/fingerprint"
-MD5s = []
-
 
 def usage():
     print "searchergen.py version pyslidversion ricercaversion buildnum"
@@ -44,7 +41,7 @@ for x, y in (
         ("RICERCA", "artifacts/ricerca-@RICERCAVERSION@-b@BUILDNUM@.tar.gz"),
         ):
 
-    find_pkg(repl, fingerprint_url, SEARCHER_RSYNC_PATH, x, y, MD5s)
+    find_pkg(repl, SEARCHER_RSYNC_PATH, x, y)
 
 
 for line in fileinput.input(["searcher_downloads.html"]):

--- a/utrack_downloads.html
+++ b/utrack_downloads.html
@@ -77,8 +77,8 @@
                                         alt="Zipped Source Code" /></a></td>
                                 <td align="center">@SOURCE_CODE_SIZE@</td>
                                 <td>@SOURCE_CODE_BASE@</td>
-                                <td align="center">@SOURCE_CODE_MD5@ (<a
-                                        href="@SOURCE_CODE@.md5">MD5</a>)</td>
+                                <td align="center">@SOURCE_CODE_SHA1@ (<a
+                                        href="@SOURCE_CODE@.sha1">SHA1</a>)</td>
                             </tr>
                         </tbody>
                     </table>

--- a/utrackgen.py
+++ b/utrackgen.py
@@ -8,8 +8,6 @@ import fileinput
 
 from doc_generator import find_pkg, repl_all
 
-fingerprint_url = "http://ci.openmicroscopy.org/fingerprint"
-
 
 def usage():
     print "utrackgen.py version"
@@ -23,9 +21,6 @@ except:
 repl = {"@VERSION@": version,
         "@MONTHYEAR@": datetime.datetime.now().strftime("%b %Y")}
 
-MD5s = []
-
-
 RSYNC_PATH = os.environ.get('RSYNC_PATH', '/ome/data_repo/public/')
 PREFIX = os.environ.get('PREFIX', 'u-track')
 UTRACK_RSYNC_PATH = '%s/%s/%s/' % (RSYNC_PATH, PREFIX, version)
@@ -35,7 +30,7 @@ for x, y in (
         ("DOC", "artifacts/u-track-@VERSION@.pdf"),
         ):
 
-    find_pkg(repl, fingerprint_url, UTRACK_RSYNC_PATH, x, y, MD5s)
+    find_pkg(repl, UTRACK_RSYNC_PATH, x, y)
 
 for line in fileinput.input(["utrack_downloads.html"]):
     print repl_all(repl, line, check_http=True),

--- a/webtagging_downloads.html
+++ b/webtagging_downloads.html
@@ -91,8 +91,8 @@
                                      /></a></td>
                                 <td align="center">@WEBTAGGING_SIZE@</td>
                                 <td>@WEBTAGGING_BASE@</td>
-                                <td align="center">@WEBTAGGING_MD5@ (<a
-                                        href="@WEBTAGGING@.md5">MD5</a>)</td>
+                                <td align="center">@WEBTAGGING_SHA1@ (<a
+                                        href="@WEBTAGGING@.sha1">SHA1</a>)</td>
                             </tr>
                         </tbody>
                     </table>

--- a/webtagginggen.py
+++ b/webtagginggen.py
@@ -9,9 +9,6 @@ import fileinput
 
 from doc_generator import find_pkg, repl_all
 
-fingerprint_url = "http://ci.openmicroscopy.org/fingerprint"
-MD5s = []
-
 
 def usage():
     print "webtagginggen.py version"
@@ -36,7 +33,7 @@ for x, y in (
         ("WEBTAGGING", "webtagging-@VERSION@.zip"),
         ):
 
-    find_pkg(repl, fingerprint_url, WEBTAGGING_RSYNC_PATH, x, y, MD5s)
+    find_pkg(repl, WEBTAGGING_RSYNC_PATH, x, y)
 
 
 for line in fileinput.input(["webtagging_downloads.html"]):


### PR DESCRIPTION
This PR adds support for exposing SHA1 checksums instead of MD5 checksums in the downloads page. Major changes are listed below:
- all checksums are now read directly from the $filename.$checksum file instead of being regenerated (CI jobs should perform the `md5sum/sha1sum -c` operation to validate checksums)
- support is added for reading SHA1 checksum and using them in the downloads page
- miscellaneous cleanup is done in `doc_generator.py` and the components `gen.py` scripts

--no-rebase
