### PR TITLE
Add hyperlink to the OMERO Python API documentation

### DIFF
--- a/omero_downloads.html
+++ b/omero_downloads.html
@@ -400,8 +400,13 @@
                 </div>
                 <ul>
                     <li>
-                        <p>Download the Python bundle matching the Ice version you are
-                           using.</p>
+                        <p>Download the Python bundle matching the Ice version
+                           you are using.</p>
+                    </li>
+                    <li>
+                        <p>The OMERO Python API documentation is also
+                           available to read on the web
+                           <a href="api/python">here</a></p>
                     </li>
                 </ul>
                 <h2><a name="java" id="java"></a>OMERO Java downloads</h2>


### PR DESCRIPTION
See https://trello.com/c/a7lHRl28/178-omero-python-api-documentation

--no-rebase
