### PR TITLE
Update MCR version for FLIMfit (rebased onto dev_5_0)

### DIFF
--- a/flimfit_downloads.html
+++ b/flimfit_downloads.html
@@ -72,7 +72,7 @@
                         <p>Mac users, please note that in order to run FLIMfit
                         you will need the correct MCR (MATLAB Compiler
                         Runtime) installed on your system (currently
-                        2013b, v8.2) which enables the execution of
+                        2014b, v8.4) which enables the execution of
                         compiled MATLAB applications or components on
                         computers that do not have MATLAB installed. If
                         you do not, or are in any doubt, please also


### PR DESCRIPTION
This is the same as gh-141 but rebased onto dev_5_0.

---

As described above. For 4.8 release.
