### PR TITLE
Updates for FLIMfit 4.9

### DIFF
--- a/flimfit_downloads.html
+++ b/flimfit_downloads.html
@@ -54,7 +54,7 @@
             <div class="entry-content" style="margin-left:20px;">
                 <h2>FLIMfit @VERSION@ Downloads</h2>
                 <p>
-                    <strong><a href="#flimfit_50">FLIMfit</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
+                    <strong><a href="#flimfit_51">FLIMfit</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
                             href="#mcr">MCR</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
                             href="#code">Code</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
                             href="#previous">Previous versions</a>

--- a/flimfit_downloads.html
+++ b/flimfit_downloads.html
@@ -62,8 +62,8 @@
                 <ul>
                     <li>
                         <p>Please note that this version of FLIMfit is compatible
-                        with OMERO 5.0 servers. If you require compatibility with
-                        an OMERO 4.4 server, earlier versions are available from
+                        with OMERO 5.1 servers. If you require compatibility with
+                        an OMERO 5.0 server, earlier versions are available from
                         the main <a
                         href="http://downloads.openmicroscopy.org/flimfit/?C=M;O=D"
                             >downloads folder</a>. </p>
@@ -101,10 +101,10 @@
                         </p>
                     </li>
                 </ul>
-                <h2><a name="flimfit_50" id="flimfit_50"></a>FLIMfit downloads
-                    for OMERO 5.0.x</h2>
+                <h2><a name="flimfit_51" id="flimfit_51"></a>FLIMfit downloads
+                    for OMERO 5.1.x</h2>
                 <div class="alt-table">
-                    <table width="800" border="0" cellpadding="5" summary="FLIMfit for OMERO 5.0.x Downloads">
+                    <table width="800" border="0" cellpadding="5" summary="FLIMfit for OMERO 5.1.x Downloads">
                         <tbody>
                             <tr>
                                 <th width="269">Clients</th>
@@ -113,25 +113,25 @@
                                 <th width="125">Checksum</th>
                             </tr>
                             <tr>
-                                <td><a href="@FLIMFIT_50_MAC@"><img
+                                <td><a href="@FLIMFIT_51_MAC@"><img
                                         src="images/flimfit_mac.png"
                                         alt="Mac OS X Client Download"
                                      /></a></td>
-                                <td align="center">@FLIMFIT_50_MAC_SIZE@</td>
-                                <td>@FLIMFIT_50_MAC_BASE@</td>
-                                <td align="center">@FLIMFIT_50_MAC_MD5@ (<a
-                                        href="@FLIMFIT_50_MAC@.md5"
+                                <td align="center">@FLIMFIT_51_MAC_SIZE@</td>
+                                <td>@FLIMFIT_51_MAC_BASE@</td>
+                                <td align="center">@FLIMFIT_51_MAC_MD5@ (<a
+                                        href="@FLIMFIT_51_MAC@.md5"
                                     >MD5</a>)</td>
                             </tr>
                             <tr>
-                                <td><a href="@FLIMFIT_50_WIN@"><img
+                                <td><a href="@FLIMFIT_51_WIN@"><img
                                         src="images/flimfit_win.png"
                                         alt="Windows Client Download"
                                      /></a></td>
-                                <td align="center">@FLIMFIT_50_WIN_SIZE@</td>
-                                <td>@FLIMFIT_50_WIN_BASE@</td>
-                                <td align="center">@FLIMFIT_50_WIN_MD5@ (<a
-                                        href="@FLIMFIT_50_WIN@.md5"
+                                <td align="center">@FLIMFIT_51_WIN_SIZE@</td>
+                                <td>@FLIMFIT_51_WIN_BASE@</td>
+                                <td align="center">@FLIMFIT_51_WIN_MD5@ (<a
+                                        href="@FLIMFIT_51_WIN@.md5"
                                     >MD5</a>)</td>
                             </tr>
                         </tbody>

--- a/flimfitgen.py
+++ b/flimfitgen.py
@@ -37,8 +37,8 @@ repl["@MCR_MAC@"] = "http://www.mathworks.com/supportfiles/downloads/R2014b" \
     "/MCR_R2014b_maci64_installer.zip"
 
 for x, y in (
-        ("FLIMFIT_50_WIN", "artifacts/FLIMfit_@VERSION@_OME_5.0_x64.zip"),
-        ("FLIMFIT_50_MAC", "artifacts/FLIMfit_@VERSION@_OME_5.0_MACI64.zip"),
+        ("FLIMFIT_50_WIN", "artifacts/FLIMfit_@VERSION@_OME_5.1_x64.zip"),
+        ("FLIMFIT_50_MAC", "artifacts/FLIMfit_@VERSION@_OME_5.1_MACI64.zip"),
         ):
 
     find_pkg(repl, fingerprint_url, FLIMFIT_RSYNC_PATH, x, y, MD5s)

--- a/flimfitgen.py
+++ b/flimfitgen.py
@@ -37,8 +37,8 @@ repl["@MCR_MAC@"] = "http://www.mathworks.com/supportfiles/downloads/R2014b" \
     "/MCR_R2014b_maci64_installer.zip"
 
 for x, y in (
-        ("FLIMFIT_50_WIN", "artifacts/FLIMfit_@VERSION@_OME_5.1_x64.zip"),
-        ("FLIMFIT_50_MAC", "artifacts/FLIMfit_@VERSION@_OME_5.1_MACI64.zip"),
+        ("FLIMFIT_51_WIN", "artifacts/FLIMfit_@VERSION@_OME_5.1_x64.zip"),
+        ("FLIMFIT_51_MAC", "artifacts/FLIMfit_@VERSION@_OME_5.1_MACI64.zip"),
         ):
 
     find_pkg(repl, fingerprint_url, FLIMFIT_RSYNC_PATH, x, y, MD5s)


### PR DESCRIPTION
To build 5.1 compatible FLIMfit -having failed to do so in develop branch.
