### PR TITLE
Making va link on main OMERO new va downloads page

### DIFF
--- a/omero_downloads.html
+++ b/omero_downloads.html
@@ -93,7 +93,7 @@
                             apply for an <a
                                 href="http://qa.openmicroscopy.org.uk/registry/demo_account/"
                                 >account on our Demo server</a> or download the
-                                <a href="latest/omero-virtual-appliance">Virtual Appliance</a> to install
+                                <a href="/latest/omero-virtual-appliance">Virtual Appliance</a> to install
                             your own version locally.</p>
                     </li>
                 </ul>

--- a/omero_downloads.html
+++ b/omero_downloads.html
@@ -93,7 +93,7 @@
                             apply for an <a
                                 href="http://qa.openmicroscopy.org.uk/registry/demo_account/"
                                 >account on our Demo server</a> or download the
-                                <a href="http://www.downloads.openmicroscopy.org/latest/omero-virtual-appliance">Virtual Appliance</a> to install
+                                <a href="latest/omero-virtual-appliance">Virtual Appliance</a> to install
                             your own version locally.</p>
                     </li>
                 </ul>

--- a/omero_downloads.html
+++ b/omero_downloads.html
@@ -93,7 +93,7 @@
                             apply for an <a
                                 href="http://qa.openmicroscopy.org.uk/registry/demo_account/"
                                 >account on our Demo server</a> or download the
-                                <a href="#va">Virtual Appliance</a> to install
+                                <a href="http://www.downloads.openmicroscopy.org/latest/omero-virtual-appliance">Virtual Appliance</a> to install
                             your own version locally.</p>
                     </li>
                 </ul>


### PR DESCRIPTION
During 5.1.3 testing, we realised we had removed the VA section from the main OMERO downloads page but forgotten to update the link in the body text. Instead of doing nothing, link will now go to new separate VA downloads page.
