### PR TITLE
Remove out-of-date Ice version sentence from omero downloads page

### DIFF
--- a/omero_downloads.html
+++ b/omero_downloads.html
@@ -318,10 +318,6 @@
                 </div>
                 <ul>
                     <li>
-                        <p>Download the Python bundle matching the Ice version
-                           you are using.</p>
-                    </li>
-                    <li>
                         <p>The OMERO Python API documentation is also
                            available to read on the web
                            <a href="api/python">here</a></p>


### PR DESCRIPTION
This removes an old sentence from the OMERO downloads page, that was only relevant when we offered multiple Ice versions of the Python libs.

Now we only offer Ice 3.5, so this sentence is confusing.
