### PR TITLE
Remove ref to other Ice version for API docs

### DIFF
--- a/omero_downloads.html
+++ b/omero_downloads.html
@@ -287,11 +287,6 @@
                         <p>The OMERO API documentation is also available to read
                             on the web <a href="api">here</a></p>
                     </li>
-                    <li>
-                        <p>Zipped files of API documentation for other versions
-                            of Ice are available as part of the <a
-                                href="#components">build components</a></p>
-                    </li>
                 </ul>
                 <h2><a name="py" id="py"></a>OMERO Python downloads</h2>
                 <div class="alt-table">


### PR DESCRIPTION
As described - all the build artifacts are currently Ice 35
