### PR TITLE
Remove VM from OMERO page & add last version note

### DIFF
--- a/omero_downloads.html
+++ b/omero_downloads.html
@@ -92,7 +92,7 @@
                         <p>If you do not have an institutional server, you can
                             apply for an <a
                                 href="http://qa.openmicroscopy.org.uk/registry/demo_account/"
-                                >account on our Demo server</a>.</p>
+                                >account on our Demo server</a></p>
                     </li>
                 </ul>
                 <h2><a name="clients" id="clients"></a>OMERO client
@@ -143,7 +143,7 @@
                     <li>
                         <p> OMERO.web is part of the server package, so
                             individual users do not need to install it
-                            locally.</p>
+                            locally</p>
                     </li>
                     <li>
                         <p>Full instructions for installing the client are on

--- a/omero_downloads.html
+++ b/omero_downloads.html
@@ -92,9 +92,7 @@
                         <p>If you do not have an institutional server, you can
                             apply for an <a
                                 href="http://qa.openmicroscopy.org.uk/registry/demo_account/"
-                                >account on our Demo server</a> or download the
-                                <a href="/latest/omero-virtual-appliance">Virtual Appliance</a> to install
-                            your own version locally.</p>
+                                >account on our Demo server</a>.</p>
                     </li>
                 </ul>
                 <h2><a name="clients" id="clients"></a>OMERO client

--- a/omerova_downloads.html
+++ b/omerova_downloads.html
@@ -63,7 +63,12 @@
                     <li>
                         <p>Information on this release of OMERO is in the <a
                                 href="@ANNOUNCEMENT_URL@">release
-                                announcement</a></p>
+                                announcement</a>.</p>
+                    </li>
+                    <li>
+                        <p><strong>Note that this is the final release of the
+                            OMERO Virtual Appliance as this tool has been
+                            discontinued as of OMERO 5.2.2.</strong></p>
                     </li>
                 </ul>
                 <h2><a name="va" id="va"></a>OMERO Virtual Appliance

--- a/omerova_downloads.html
+++ b/omerova_downloads.html
@@ -63,12 +63,12 @@
                     <li>
                         <p>Information on this release of OMERO is in the <a
                                 href="@ANNOUNCEMENT_URL@">release
-                                announcement</a>.</p>
+                                announcement</a></p>
                     </li>
                     <li>
                         <p><strong>Note that this is the final release of the
                             OMERO Virtual Appliance as this tool has been
-                            discontinued as of OMERO 5.2.2.</strong></p>
+                            discontinued as of OMERO 5.2.2</strong></p>
                     </li>
                 </ul>
                 <h2><a name="va" id="va"></a>OMERO Virtual Appliance


### PR DESCRIPTION
See https://trello.com/c/gKMVgoQ8/3-consider-replacing-virtual-applicance-with-docker
Since no new version of the VM is being released for 5.2.2, this removes mention on it from the OMERO downloads page and adds a note to the VM download page to clarify that it is the last version.
