### PR TITLE
Adding internal release warning for milestones

### DIFF
--- a/bf_downloads.html
+++ b/bf_downloads.html
@@ -53,6 +53,13 @@
             <!-- OME Banner - END -->
             <div class="entry-content" style="margin-left:20px;">
                 <h2>Bio-Formats @VERSION@ Downloads</h2>
+                <div style="background-color: #F5A9A9; margin-left: 20px; margin-right: 20px; margin-bottom: 20px; margin-top: 20px; padding-bottom: 8px; padding-left: 8px; padding-right: 8px; padding-top: 8px;">
+                <b>WARNING</b><br/>
+                This is a internal developer release <b>NOT INTENDED FOR
+                USE BY EXTERNAL DEVELOPERS AND DEFINITELY NOT FOR USE IN
+                PRODUCTION</b>. The Model and API are still subject to change
+                at this stage.
+                </div>
                     <p><strong><a href="#tools"
                             >Tools</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#api"
                             >API</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a


### PR DESCRIPTION
Milestone releases will be public but not linked anywhere. This adds a warning to make very clear that external users should not use this release if they do manage to find it, as we have discovered cases of people using milestone releases in the past.
