### PR TITLE
Updating copyright years on downloads pages

### DIFF
--- a/bf_downloads.html
+++ b/bf_downloads.html
@@ -426,7 +426,7 @@
                 ><!-- --></div>
             <div id="portal-footer">
                 <p>
-                    <acronym title="Copyright">&copy;</acronym> 2000-2016
+                    <acronym title="Copyright">&copy;</acronym> 2000-@YEAR@
                     University of Dundee &amp; Open Microscopy Environment. <a
                         href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
                         >Creative Commons Attribution 3.0 Unported License</a>

--- a/bf_downloads.html
+++ b/bf_downloads.html
@@ -426,7 +426,7 @@
                 ><!-- --></div>
             <div id="portal-footer">
                 <p>
-                    <acronym title="Copyright">&copy;</acronym> 2000-2014
+                    <acronym title="Copyright">&copy;</acronym> 2000-2016
                     University of Dundee &amp; Open Microscopy Environment. <a
                         href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
                         >Creative Commons Attribution 3.0 Unported License</a>

--- a/bfgen.py
+++ b/bfgen.py
@@ -23,7 +23,8 @@ except:
     usage()
 
 repl = {"@VERSION@": version,
-        "@MONTHYEAR@": datetime.datetime.now().strftime("%b %Y")}
+        "@MONTHYEAR@": datetime.datetime.now().strftime("%b %Y"),
+        "@YEAR@": datetime.datetime.now().strftime("%Y")}
 
 # Read major and minor version from input version
 major_version, minor_version = get_version(version)

--- a/figure_downloads.html
+++ b/figure_downloads.html
@@ -104,7 +104,7 @@
         <div class="visualClear" id="clear-space-before-footer"><!-- --></div>
         <div id="portal-footer">
             <p>
-                <acronym title="Copyright">&copy;</acronym> 2000-2016 University
+                <acronym title="Copyright">&copy;</acronym> 2000-@YEAR@ University
                 of Dundee &amp; Open Microscopy Environment. <a
                     href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
                     >Creative Commons Attribution 4.0 International License</a>

--- a/figure_downloads.html
+++ b/figure_downloads.html
@@ -104,7 +104,7 @@
         <div class="visualClear" id="clear-space-before-footer"><!-- --></div>
         <div id="portal-footer">
             <p>
-                <acronym title="Copyright">&copy;</acronym> 2000-2015 University
+                <acronym title="Copyright">&copy;</acronym> 2000-2016 University
                 of Dundee &amp; Open Microscopy Environment. <a
                     href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
                     >Creative Commons Attribution 4.0 International License</a>

--- a/figuregen.py
+++ b/figuregen.py
@@ -21,7 +21,8 @@ except:
     usage()
 
 repl = {"@VERSION@": version,
-        "@MONTHYEAR@": datetime.datetime.now().strftime("%b %Y")}
+        "@MONTHYEAR@": datetime.datetime.now().strftime("%b %Y"),
+        "@YEAR@": datetime.datetime.now().strftime("%Y")}
 
 PREFIX = os.environ.get('PREFIX', 'figure')
 FIGURE_RSYNC_PATH = '%s/%s/%s/' % (RSYNC_PATH, PREFIX, version)

--- a/files_cpp_downloads.html
+++ b/files_cpp_downloads.html
@@ -573,7 +573,7 @@
                 ><!-- --></div>
             <div id="portal-footer">
                 <p>
-                    <acronym title="Copyright">&copy;</acronym> 2000-2016
+                    <acronym title="Copyright">&copy;</acronym> 2000-@YEAR@
                     University of Dundee &amp; Open Microscopy Environment. <a
                         href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
                         >Creative Commons Attribution 3.0 Unported License</a>

--- a/files_cpp_downloads.html
+++ b/files_cpp_downloads.html
@@ -573,7 +573,7 @@
                 ><!-- --></div>
             <div id="portal-footer">
                 <p>
-                    <acronym title="Copyright">&copy;</acronym> 2000-2014
+                    <acronym title="Copyright">&copy;</acronym> 2000-2016
                     University of Dundee &amp; Open Microscopy Environment. <a
                         href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
                         >Creative Commons Attribution 3.0 Unported License</a>

--- a/filescppgen.py
+++ b/filescppgen.py
@@ -37,7 +37,8 @@ repl = {"@VERSION@": files_version,
         "@FILES_VERSION@": files_version,
         "@QTWIDGETS_VERSION@": qtwidgets_version,
         "@SUPERBUILD_VERSION@": superbuild_version,
-        "@MONTHYEAR@": datetime.datetime.now().strftime("%b %Y")}
+        "@MONTHYEAR@": datetime.datetime.now().strftime("%b %Y"),
+        "@YEAR@": datetime.datetime.now().strftime("%Y")}
 
 repl["@SUPERBUILD_TAG_URL@"] = get_tag_url("ome-cmake-superbuild",
                                            superbuild_version,

--- a/gen.py
+++ b/gen.py
@@ -22,7 +22,8 @@ except:
 
 repl = {"@VERSION@": version,
         "@BUILD@": build,
-        "@MONTHYEAR@": datetime.datetime.now().strftime("%b %Y")}
+        "@MONTHYEAR@": datetime.datetime.now().strftime("%b %Y"),
+        "@YEAR@": datetime.datetime.now().strftime("%Y")}
 
 major_version, minor_version = get_version(version)
 

--- a/ice_downloads.html
+++ b/ice_downloads.html
@@ -118,7 +118,7 @@
                 ><!-- --></div>
             <div id="portal-footer">
                 <p>
-                    <acronym title="Copyright">&copy;</acronym> 2000-2016
+                    <acronym title="Copyright">&copy;</acronym> 2000-@YEAR@
                     University of Dundee &amp; Open Microscopy Environment. <a
                         href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
                         >Creative Commons Attribution 3.0 Unported License</a>

--- a/ice_downloads.html
+++ b/ice_downloads.html
@@ -118,7 +118,7 @@
                 ><!-- --></div>
             <div id="portal-footer">
                 <p>
-                    <acronym title="Copyright">&copy;</acronym> 2000-2014
+                    <acronym title="Copyright">&copy;</acronym> 2000-2016
                     University of Dundee &amp; Open Microscopy Environment. <a
                         href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
                         >Creative Commons Attribution 3.0 Unported License</a>

--- a/icegen.py
+++ b/icegen.py
@@ -28,7 +28,8 @@ except:
 repl = {"@VERSION@": version,
         "@BUILD@": build,
         "@SOURCE_SUFFIX@": source_suffix,
-        "@MONTHYEAR@": datetime.datetime.now().strftime("%b %Y")}
+        "@MONTHYEAR@": datetime.datetime.now().strftime("%b %Y"),
+        "@YEAR@": datetime.datetime.now().strftime("%Y")}
 
 PREFIX = os.environ.get('PREFIX', 'ice')
 ICE_RSYNC_PATH = '%s/%s/%s/' % (RSYNC_PATH, PREFIX, version)

--- a/mtools_downloads.html
+++ b/mtools_downloads.html
@@ -154,7 +154,7 @@
                 ><!-- --></div>
             <div id="portal-footer">
                 <p>
-                    <acronym title="Copyright">&copy;</acronym> 2000-2016
+                    <acronym title="Copyright">&copy;</acronym> 2000-@YEAR@
                     University of Dundee &amp; Open Microscopy Environment. <a
                         href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
                         >Creative Commons Attribution 4.0 International License</a>

--- a/mtools_downloads.html
+++ b/mtools_downloads.html
@@ -154,7 +154,7 @@
                 ><!-- --></div>
             <div id="portal-footer">
                 <p>
-                    <acronym title="Copyright">&copy;</acronym> 2000-2015
+                    <acronym title="Copyright">&copy;</acronym> 2000-2016
                     University of Dundee &amp; Open Microscopy Environment. <a
                         href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
                         >Creative Commons Attribution 4.0 International License</a>

--- a/mtoolsgen.py
+++ b/mtoolsgen.py
@@ -20,7 +20,8 @@ except:
     usage()
 
 repl = {"@VERSION@": version,
-        "@MONTHYEAR@": datetime.datetime.now().strftime("%b %Y")}
+        "@MONTHYEAR@": datetime.datetime.now().strftime("%b %Y"),
+        "@YEAR@": datetime.datetime.now().strftime("%Y")}
 
 PREFIX = os.environ.get('PREFIX', 'mtools')
 UTRACK_RSYNC_PATH = '%s/%s/%s/' % (RSYNC_PATH, PREFIX, version)

--- a/omero_downloads.html
+++ b/omero_downloads.html
@@ -424,7 +424,7 @@
                 ><!-- --></div>
             <div id="portal-footer">
                 <p>
-                    <acronym title="Copyright">&copy;</acronym> 2000-2015
+                    <acronym title="Copyright">&copy;</acronym> 2000-2016
                     University of Dundee &amp; Open Microscopy Environment. <a
                         href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
                         >Creative Commons Attribution 3.0 Unported License</a>

--- a/omero_downloads.html
+++ b/omero_downloads.html
@@ -424,7 +424,7 @@
                 ><!-- --></div>
             <div id="portal-footer">
                 <p>
-                    <acronym title="Copyright">&copy;</acronym> 2000-2016
+                    <acronym title="Copyright">&copy;</acronym> 2000-@YEAR@
                     University of Dundee &amp; Open Microscopy Environment. <a
                         href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
                         >Creative Commons Attribution 3.0 Unported License</a>

--- a/searcher_downloads.html
+++ b/searcher_downloads.html
@@ -126,7 +126,7 @@
                 ><!-- --></div>
             <div id="portal-footer">
                 <p>
-                    <acronym title="Copyright">&copy;</acronym> 2000-2016
+                    <acronym title="Copyright">&copy;</acronym> 2000-@YEAR@
                     University of Dundee &amp; Open Microscopy Environment. <a
                         href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
                         >Creative Commons Attribution 3.0 Unported License</a>

--- a/searcher_downloads.html
+++ b/searcher_downloads.html
@@ -126,7 +126,7 @@
                 ><!-- --></div>
             <div id="portal-footer">
                 <p>
-                    <acronym title="Copyright">&copy;</acronym> 2000-2014
+                    <acronym title="Copyright">&copy;</acronym> 2000-2016
                     University of Dundee &amp; Open Microscopy Environment. <a
                         href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
                         >Creative Commons Attribution 3.0 Unported License</a>

--- a/searchergen.py
+++ b/searchergen.py
@@ -27,7 +27,8 @@ repl = {"@VERSION@": version,
         "@PYSLIDVERSION@": pyslidversion,
         "@RICERCAVERSION@": ricercaversion,
         "@BUILDNUM@": buildnum,
-        "@MONTHYEAR@": datetime.datetime.now().strftime("%b %Y")}
+        "@MONTHYEAR@": datetime.datetime.now().strftime("%b %Y"),
+        "@YEAR@": datetime.datetime.now().strftime("%Y")}
 
 PREFIX = os.environ.get('PREFIX', 'searcher')
 SEARCHER_RSYNC_PATH = '%s/%s/%s/' % (RSYNC_PATH, PREFIX, version)

--- a/utrack_downloads.html
+++ b/utrack_downloads.html
@@ -119,7 +119,7 @@
                 ><!-- --></div>
             <div id="portal-footer">
                 <p>
-                    <acronym title="Copyright">&copy;</acronym> 2000-2014
+                    <acronym title="Copyright">&copy;</acronym> 2000-2016
                     University of Dundee &amp; Open Microscopy Environment. <a
                         href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
                         >Creative Commons Attribution 3.0 Unported License</a>

--- a/utrack_downloads.html
+++ b/utrack_downloads.html
@@ -119,7 +119,7 @@
                 ><!-- --></div>
             <div id="portal-footer">
                 <p>
-                    <acronym title="Copyright">&copy;</acronym> 2000-2016
+                    <acronym title="Copyright">&copy;</acronym> 2000-@YEAR@
                     University of Dundee &amp; Open Microscopy Environment. <a
                         href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
                         >Creative Commons Attribution 3.0 Unported License</a>

--- a/utrackgen.py
+++ b/utrackgen.py
@@ -20,7 +20,8 @@ except:
     usage()
 
 repl = {"@VERSION@": version,
-        "@MONTHYEAR@": datetime.datetime.now().strftime("%b %Y")}
+        "@MONTHYEAR@": datetime.datetime.now().strftime("%b %Y"),
+        "@YEAR@": datetime.datetime.now().strftime("%Y")}
 
 PREFIX = os.environ.get('PREFIX', 'u-track')
 UTRACK_RSYNC_PATH = '%s/%s/%s/' % (RSYNC_PATH, PREFIX, version)

--- a/webtagging_downloads.html
+++ b/webtagging_downloads.html
@@ -98,7 +98,7 @@
                 ><!-- --></div>
             <div id="portal-footer">
                 <p>
-                    <acronym title="Copyright">&copy;</acronym> 2000-2014
+                    <acronym title="Copyright">&copy;</acronym> 2000-2016
                     University of Dundee &amp; Open Microscopy Environment. <a
                         href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
                         >Creative Commons Attribution 3.0 Unported License</a>

--- a/webtagging_downloads.html
+++ b/webtagging_downloads.html
@@ -98,7 +98,7 @@
                 ><!-- --></div>
             <div id="portal-footer">
                 <p>
-                    <acronym title="Copyright">&copy;</acronym> 2000-2016
+                    <acronym title="Copyright">&copy;</acronym> 2000-@YEAR@
                     University of Dundee &amp; Open Microscopy Environment. <a
                         href="http://www.openmicroscopy.org/site/about/licensing-attribution/licensing"
                         >Creative Commons Attribution 3.0 Unported License</a>

--- a/webtagginggen.py
+++ b/webtagginggen.py
@@ -21,7 +21,8 @@ except:
     usage()
 
 repl = {"@VERSION@": version,
-        "@MONTHYEAR@": datetime.datetime.now().strftime("%b %Y")}
+        "@MONTHYEAR@": datetime.datetime.now().strftime("%b %Y"),
+        "@YEAR@": datetime.datetime.now().strftime("%Y")}
 
 PREFIX = os.environ.get('PREFIX', 'webtagging')
 WEBTAGGING_RSYNC_PATH = '%s/%s/%s/' % (RSYNC_PATH, PREFIX, version)


### PR DESCRIPTION
This was prompted by https://trello.com/c/w1ywT02g/8-downloads-copyright but I figured I may as well update all the pages while I was at it.

Not sure if we want to update all the licenses too, I'm unclear whether we are actually supposed to change CC licenses for existing products, although Jason did ask me to update the schema license to 4.0 so I guess we could.
