### PR TITLE
Adding warning banner to redirect FLIMfit users

### DIFF
--- a/flimfit_downloads.html
+++ b/flimfit_downloads.html
@@ -53,6 +53,12 @@
             <!-- OME Banner - END -->
             <div class="entry-content" style="margin-left:20px;">
                 <h2>FLIMfit @VERSION@ Downloads</h2>
+                <div style="background-color: #F5A9A9; margin-left: 20px; margin-right: 20px; margin-bottom: 20px; margin-top: 20px; padding-bottom: 8px; padding-left: 8px; padding-right: 8px; padding-top: 8px;">
+                                <b>WARNING</b><br/>
+                                This is the last version of FLIMfit available
+                                from downloads.openmicroscopy.org. For current
+                                and future releases, please see <a href="http://flimfit.org/downloads/">flimfit.org</a> instead.
+                                </div>
                 <p>
                     <strong><a href="#flimfit_51">FLIMfit</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a
                             href="#mcr">MCR</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a


### PR DESCRIPTION
See https://trello.com/c/OTmOTWgb/65-flimfit-downloads-redirects
This adds a red warning banner along the lines on the one on http://downloads.openmicroscopy.org/bio-formats/5.2.0-m3/ to the top of the last FLIMfit version we are hosting http://downloads.openmicroscopy.org/flimfit/4.11.0/
