### PR TITLE
downloads: give better example for compatible client versions.

### DIFF
--- a/omero_downloads.html
+++ b/omero_downloads.html
@@ -85,8 +85,9 @@
                     <li>
                         <p>A standard OMERO user just needs to download the
                             client package with the same major version as their
-                            institutional server e.g. 5.0 clients with the 5.0
-                            server</p>
+                            institutional server e.g., 5.0.0 clients will
+                            connect to 5.0.8 servers but not to 5.1.0
+                            servers.</p>
                     </li>
                     <li>
                         <p>If you do not have an institutional server, you can


### PR DESCRIPTION
The current example about what server versions a client supports is not clear. The example:

> the client package with the same major version as their institutional server e.g. 5.0 clients with the 5.0 server

is confusing because the major version is often considered the first number (major.minor.patch). Using major.minor.patch, the example is correct but then that would mean that a 5.2.2 client will work with a 6.0.0 omero server.
