### PR TITLE
Remove dev preview warning banner from BF 5.2

### DIFF
--- a/bf_downloads.html
+++ b/bf_downloads.html
@@ -147,18 +147,18 @@
                     </li>
                     <li>
                         <p>@COMMAND_LINE_TOOLS_BASE@ is a bundle of scripts for
-                            using Bio-Formats on the command line <b>now with
+                            using Bio-Formats on the command line with
                                 bioformats_package.jar included so you do not
-                                have to install both separately</b>. See the <a
+                                have to install both separately. See the <a
                                 href="@DOC_URL@/users/comlinetools/index.html"
                                 >command line tools documentation</a> for
                             further information.</p>
                     </li>
                     <li>
                         <p>@MATLAB_TOOLS_BASE@ is a bundle of functions for
-                            using Bio-Formats from MATLAB <b>now with
+                            using Bio-Formats from MATLAB with
                                 bioformats_package.jar included so you do not
-                                have to install both separately</b>. See the <a
+                                have to install both separately. See the <a
                                 href="@DOC_URL@/users/matlab/index.html">MATLAB
                                 documentation</a> for further information.</p>
                     </li>

--- a/bf_downloads.html
+++ b/bf_downloads.html
@@ -53,13 +53,6 @@
             <!-- OME Banner - END -->
             <div class="entry-content" style="margin-left:20px;">
                 <h2>Bio-Formats @VERSION@ Downloads</h2>
-                <div style="background-color: #F5A9A9; margin-left: 20px; margin-right: 20px; margin-bottom: 20px; margin-top: 20px; padding-bottom: 8px; padding-left: 8px; padding-right: 8px; padding-top: 8px;">
-                <b>WARNING</b><br/>
-                This is a internal developer release <b>NOT INTENDED FOR
-                USE BY EXTERNAL DEVELOPERS AND DEFINITELY NOT FOR USE IN
-                PRODUCTION</b>. The Model and API are still subject to change
-                at this stage.
-                </div>
                     <p><strong><a href="#tools"
                             >Tools</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#api"
                             >API</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a


### PR DESCRIPTION
This banner needs to go to 5.2.0 release

To be reviewed for rc1
