### PR TITLE
Bio-Formats components: latest column drop

### DIFF
--- a/bf_downloads.html
+++ b/bf_downloads.html
@@ -210,137 +210,103 @@
                             <tr>
                                 <th width="180">Project</th>
                                 <th width="150">@VERSION@</th>
-                                <th width="150">Latest build</th>
                             </tr>
                             <tr>
-                                <th colspan="3">Package</th>
+                                <th colspan="2">Package</th>
                             </tr>
                             <tr>
                                 <td>Bio-Formats package</td>
                                 <td><a href="@bioformats_package.jar@"
-                                        >bioformats_package.jar</a></td>
-                                <td><a href="@LATEST_bioformats_package.jar@"
                                         >bioformats_package.jar</a></td>
                             </tr>
                             <tr>
                                 <td>LOCI Tools</td>
                                 <td><a href="@loci_tools.jar@"
                                         >loci_tools.jar</a></td>
-                                <td><a href="@LATEST_loci_tools.jar@"
-                                        >loci_tools.jar</a></td>
                             </tr>
                             <tr>
-                                <th colspan="3">Core</th>
+                                <th colspan="2">Core</th>
                             </tr>
                             <tr>
                                 <td>Bio-Formats API library</td>
                                 <td><a href="@formats-api.jar@"
-                                        >formats-api.jar</a></td>
-                                <td><a href="@LATEST_formats-api.jar@"
                                         >formats-api.jar</a></td>
                             </tr>
                             <tr>
                                 <td>Bio-Formats BSD library</td>
                                 <td><a href="@formats-bsd.jar@"
                                         >formats-bsd.jar</a></td>
-                                <td><a href="@LATEST_formats-bsd.jar@"
-                                        >formats-bsd.jar</a></td>
                             </tr>
                             <tr>
                                 <td>Bio-Formats Common library</td>
                                 <td><a href="@formats-common.jar@"
-                                        >formats-common.jar</a></td>
-                                <td><a href="@LATEST_formats-common.jar@"
                                         >formats-common.jar</a></td>
                             </tr>
                             <tr>
                                 <td>Bio-Formats GPL library</td>
                                 <td><a href="@formats-gpl.jar@"
                                         >formats-gpl.jar</a></td>
-                                <td><a href="@LATEST_formats-gpl.jar@"
-                                        >formats-gpl.jar</a></td>
                             </tr>
                             <tr>
                                 <td>Bio-Formats BSD Test library</td>
                                 <td><a href="@formats-bsd-test.jar@"
                                         >formats-bsd-test.jar</a></td>
-                                <td><a href="@LATEST_formats-bsd-test.jar@"
-                                        >formats-bsd-test.jar</a></td>
                             </tr>
                             <tr>
                                 <td>OME-XML Java library</td>
-                                <td><a href="@ome-xml.jar@">ome-xml.jar</a></td>
-                                <td><a href="@LATEST_ome-xml.jar@"
-                                        >ome-xml.jar</a></td>
+                                <td><a href="@ome-xml.jar@"
+                                       >ome-xml.jar</a></td>
                             </tr>
                             <tr>
                                 <td>OME Model Specification</td>
                                 <td><a href="@specification.jar@"
-                                        >specification.jar</a></td>
-                                <td><a href="@LATEST_specification.jar@"
                                         >specification.jar</a></td>
                             </tr>
                             <tr>
                                 <td>Bio-Formats Plugins for ImageJ</td>
                                 <td><a href="@bio-formats_plugins.jar@"
                                         >bio-formats_plugins.jar</a></td>
-                                <td><a href="@LATEST_bio-formats_plugins.jar@"
-                                        >bio-formats_plugins.jar</a></td>
                             </tr>
                             <tr>
                                 <td>Metakit</td>
-                                <td><a href="@metakit.jar@">metakit.jar</a></td>
-                                <td><a href="@LATEST_metakit.jar@"
-                                        >metakit.jar</a></td>
+                                <td><a href="@metakit.jar@"
+                                       >metakit.jar</a></td>
                             </tr>
                             <tr>
                                 <td>Bio-Formats testing framework</td>
                                 <td><a
                                         href="@bio-formats-testing-framework.jar@"
                                         >bio-formats-testing-framework.jar</a></td>
-                                <td><a
-                                        href="@LATEST_bio-formats-testing-framework.jar@"
-                                        >bio-formats-testing-framework.jar</a></td>
                             </tr>
                             <tr>
-                                <th align="center" colspan="3">Fork</th>
+                                <th align="center" colspan="2">Fork</th>
                             </tr>
                             <tr>
                                 <td>JAI Image I/O Tools</td>
                                 <td><a href="@jai_imageio.jar@"
-                                        >jai_imageio.jar</a></td>
-                                <td><a href="@LATEST_jai_imageio.jar@"
                                         >jai_imageio.jar</a></td>
                             </tr>
                             <tr>
                                 <td>MDB Tools (Java port)</td>
                                 <td><a href="@mdbtools-java.jar@"
                                         >mdbtools-java.jar</a></td>
-                                <td><a href="@LATEST_mdbtools-java.jar@"
-                                        >mdbtools-java.jar</a></td>
                             </tr>
                             <tr>
                                 <td>Apache Jakarta POI</td>
                                 <td><a href="@ome-poi.jar@">ome-poi.jar</a></td>
-                                <td><a href="@LATEST_ome-poi.jar@"
-                                        >ome-poi.jar</a></td>
                             </tr>
                             <tr>
                                 <td>TurboJPEG</td>
                                 <td><a href="@turbojpeg.jar@"
                                     >turbojpeg.jar</a></td>
-                                <td><a href="@LATEST_turbojpeg.jar@"
-                                        >turbojpeg.jar</a></td>
                             </tr>
                             <tr>
-                                <th align="center" colspan="3">Stub</th>
+                                <th align="center" colspan="1">Stub</th>
                             </tr>
                             <tr>
                                 <td>Luratech LuraWave stubs</td>
                                 <td><a href="@lwf-stubs.jar@"
                                     >lwf-stubs.jar</a></td>
-                                <td><a href="@LATEST_lwf-stubs.jar@"
-                                        >lwf-stubs.jar</a></td>
                             </tr>
                         </tbody>
                     </table>

--- a/bf_downloads.html
+++ b/bf_downloads.html
@@ -301,7 +301,7 @@
                                     >turbojpeg.jar</a></td>
                             </tr>
                             <tr>
-                                <th align="center" colspan="1">Stub</th>
+                                <th align="center" colspan="2">Stub</th>
                             </tr>
                             <tr>
                                 <td>Luratech LuraWave stubs</td>

--- a/bfgen.py
+++ b/bfgen.py
@@ -9,9 +9,6 @@ import fileinput
 from utils import RSYNC_PATH, get_version, get_tag_url
 from doc_generator import find_pkg, repl_all
 
-latest_url = ("http://ci.openmicroscopy.org/job/BIOFORMATS-5.1-latest/"
-              "lastSuccessfulBuild/artifact/artifacts")
-
 
 def usage():
     print "bfgen.py version"
@@ -66,8 +63,6 @@ for x, y in (
         ):
 
     find_pkg(repl, BF_RSYNC_PATH, x, y)
-
-    repl["@LATEST_%s@" % x] = "%s/%s" % (latest_url, x)
 
 for line in fileinput.input(["bf_downloads.html"]):
     print repl_all(repl, line, check_http=True),


### PR DESCRIPTION
While reviewing 5.2.0 release candidates, I noticed the URLs of the latest build column were outdated (pointing to 5.1 builds).
As Bio-formats has its own decoupled lifecycle, pointing to CI resources in a downloads page is of little value and potentially confusing. This PR proposes to completely drop this latest build column in favor of a simple listing of the individual release components.
