### PR TITLE
Changes for 5.3.0-m2

### DIFF
--- a/bf_downloads.html
+++ b/bf_downloads.html
@@ -221,8 +221,8 @@
                             </tr>
                             <tr>
                                 <td>LOCI Tools</td>
-                                <td><a href="@loci-tools.jar@"
-                                        >loci-tools.jar</a></td>
+                                <td><a href="@loci_tools.jar@"
+                                        >loci_tools.jar</a></td>
                             </tr>
                             <tr>
                                 <th colspan="2">Core</th>

--- a/bf_downloads.html
+++ b/bf_downloads.html
@@ -248,11 +248,6 @@
                                         >bio-formats_plugins.jar</a></td>
                             </tr>
                             <tr>
-                                <td>Metakit</td>
-                                <td><a href="@metakit.jar@"
-                                       >metakit.jar</a></td>
-                            </tr>
-                            <tr>
                                 <td>Bio-Formats testing framework</td>
                                 <td><a
                                         href="@bio-formats-testing-framework.jar@"
@@ -270,14 +265,6 @@
                                 <td>TurboJPEG</td>
                                 <td><a href="@turbojpeg.jar@"
                                     >turbojpeg.jar</a></td>
-                            </tr>
-                            <tr>
-                                <th align="center" colspan="2">Stub</th>
-                            </tr>
-                            <tr>
-                                <td>Luratech LuraWave stubs</td>
-                                <td><a href="@lwf-stubs.jar@"
-                                    >lwf-stubs.jar</a></td>
                             </tr>
                         </tbody>
                     </table>

--- a/bfgen.py
+++ b/bfgen.py
@@ -51,8 +51,6 @@ for x, y in (
         ("formats-gpl.jar", "artifacts/formats-gpl.jar"),
         ("jai_imageio.jar", "artifacts/jai_imageio.jar"),
         ("loci_tools.jar", "artifacts/loci_tools.jar"),
-        ("lwf-stubs.jar", "artifacts/lwf-stubs.jar"),
-        ("metakit.jar", "artifacts/metakit.jar"),
         ("turbojpeg.jar", "artifacts/turbojpeg.jar"),
         ):
 

--- a/bfgen.py
+++ b/bfgen.py
@@ -50,7 +50,7 @@ for x, y in (
         ("formats-bsd.jar", "artifacts/formats-bsd.jar"),
         ("formats-gpl.jar", "artifacts/formats-gpl.jar"),
         ("jai_imageio.jar", "artifacts/jai_imageio.jar"),
-        ("loci-tools.jar", "artifacts/loci-tools.jar"),
+        ("loci_tools.jar", "artifacts/loci_tools.jar"),
         ("lwf-stubs.jar", "artifacts/lwf-stubs.jar"),
         ("metakit.jar", "artifacts/metakit.jar"),
         ("turbojpeg.jar", "artifacts/turbojpeg.jar"),


### PR DESCRIPTION
Summary of changes

- reverts commit 04a84ee296614797e4f1f6ad5c8d4c6c636939cd following https://github.com/openmicroscopy/bioformats/pull/2645
- removes metakit and stubs following https://github.com/openmicroscopy/bioformats/pull/2657