### PR TITLE
Fix flake8 E305 warnings with the latest version of flake8

### DIFF
--- a/bfgen.py
+++ b/bfgen.py
@@ -14,6 +14,7 @@ def usage():
     print "bfgen.py version"
     sys.exit(1)
 
+
 try:
     version = sys.argv[1]
 except:

--- a/doc_generator.py
+++ b/doc_generator.py
@@ -16,6 +16,7 @@ class HeadRequest(Request):
     def get_method(self):
         return 'HEAD'
 
+
 # create an opener that will simulate a browser user-agent
 opener = build_opener()
 opener.addheaders = [('User-agent', 'Mozilla/5.0')]
@@ -106,6 +107,7 @@ def repl_all(repl, line, check_http=False):
                 if not status == 'working' and not status == 'redirected':
                     raise Exception("%s: %s" % (url, info))
     return line
+
 
 suffixes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
 

--- a/figuregen.py
+++ b/figuregen.py
@@ -15,6 +15,7 @@ def usage():
     print "figuregen.py version"
     sys.exit(1)
 
+
 try:
     version = sys.argv[1]
 except:

--- a/filescppgen.py
+++ b/filescppgen.py
@@ -14,6 +14,7 @@ def usage():
     print "filescppgen.py version buildid"
     sys.exit(1)
 
+
 try:
     files_version = sys.argv[1]
     buildid = sys.argv[2]

--- a/flimfitgen.py
+++ b/flimfitgen.py
@@ -14,6 +14,7 @@ def usage():
     print "flimfitgen.py version"
     sys.exit(1)
 
+
 try:
     version = sys.argv[1]
 except:

--- a/gen.py
+++ b/gen.py
@@ -14,6 +14,7 @@ def usage():
     print "gen.py version build"
     sys.exit(1)
 
+
 try:
     version = sys.argv[1]
     build = sys.argv[2]

--- a/icegen.py
+++ b/icegen.py
@@ -15,6 +15,7 @@ def usage():
     print "icegen.py version build [source_suffix]"
     sys.exit(1)
 
+
 try:
     version = sys.argv[1]
     build = sys.argv[2]

--- a/mtoolsgen.py
+++ b/mtoolsgen.py
@@ -14,6 +14,7 @@ def usage():
     print "mtoolsgen.py version"
     sys.exit(1)
 
+
 try:
     version = sys.argv[1]
 except:

--- a/searchergen.py
+++ b/searchergen.py
@@ -15,6 +15,7 @@ def usage():
     print "searchergen.py version pyslidversion ricercaversion buildnum"
     sys.exit(1)
 
+
 try:
     version = sys.argv[1]
     pyslidversion = sys.argv[2]

--- a/utrackgen.py
+++ b/utrackgen.py
@@ -14,6 +14,7 @@ def usage():
     print "utrackgen.py version"
     sys.exit(1)
 
+
 try:
     version = sys.argv[1]
 except:

--- a/webtagginggen.py
+++ b/webtagginggen.py
@@ -15,6 +15,7 @@ def usage():
     print "webtagginggen.py version"
     sys.exit(1)
 
+
 try:
     version = sys.argv[1]
 except:


### PR DESCRIPTION
The Travis build failed because of the latest version of flake8. Note it is likely similar issues will arise across all repos using uncapped versions of `flake8` in Travis /cc @joshmoore @jburel @will-moore @aleksandra-tarkowska 