### PR TITLE
Warn ij users to delete old versions on OMERO page

### DIFF
--- a/omero_downloads.html
+++ b/omero_downloads.html
@@ -191,7 +191,9 @@
                         <p>Instructions for downloading and installing the
                             ImageJ plugin: <a
                                 href="http://help.openmicroscopy.org/imagej.html"
-                                target="_blank">Using ImageJ with OMERO</a></p>
+                                target="_blank">Using ImageJ with OMERO</a>.
+                            If upgrading to a new version, you should delete
+                            previous plugin versions to avoid errors.</p>
                     </li>
                     <li>
                         <p>Instructions for using the Matlab plugin are at: <a


### PR DESCRIPTION
Users having old plugin versions present in the folder has caused errors a number of times. This adds a warning to the download page.

Can be tested during the next milestone release