### PR TITLE
ome-files: Update names and versions for 0.3.0 release

### DIFF
--- a/files_cpp_downloads.html
+++ b/files_cpp_downloads.html
@@ -351,16 +351,16 @@
                                 <td rowspan="2"><img src="images/square_c++.png"
                                                      alt="C++ source"/></td>
                                 <td rowspan="2">OME&nbsp;XML</td>
-                                <td rowspan="2"><a href="http://github.com/openmicroscopy/bioformats"><img src="images/square_github.png" alt="zip"/></a></td>
-                                <td rowspan="2"><a href="@XML_TAG_URL@">v@XML_VERSION@</a></td>
-                                <td><a href="@BF_SOURCE_TXZ@"><img src="images/square_txz.png" alt="txz"/></a></td>
-                                <td align="right">@BF_SOURCE_TXZ_SIZE@</td>
-                                <td align="center"><a href="@BF_SOURCE_TXZ@.sha1">@BF_SOURCE_TXZ_SHA1@</a></td>
+                                <td rowspan="2"><a href="http://github.com/ome/ome-model"><img src="images/square_github.png" alt="zip"/></a></td>
+                                <td rowspan="2"><a href="@MODEL_TAG_URL@">v@MODEL_VERSION@</a></td>
+                                <td><a href="@MODEL_SOURCE_TXZ@"><img src="images/square_txz.png" alt="txz"/></a></td>
+                                <td align="right">@MODEL_SOURCE_TXZ_SIZE@</td>
+                                <td align="center"><a href="@MODEL_SOURCE_TXZ@.sha1">@MODEL_SOURCE_TXZ_SHA1@</a></td>
                             </tr>
                             <tr>
-                                <td><a href="@BF_SOURCE_ZIP@"><img src="images/square_zip.png" alt="zip"/></a></td>
-                                <td align="right">@BF_SOURCE_ZIP_SIZE@</td>
-                                <td align="center"><a href="@BF_SOURCE_ZIP@.sha1">@BF_SOURCE_ZIP_SHA1@</a></td>
+                                <td><a href="@MODEL_SOURCE_ZIP@"><img src="images/square_zip.png" alt="zip"/></a></td>
+                                <td align="right">@MODEL_SOURCE_ZIP_SIZE@</td>
+                                <td align="center"><a href="@MODEL_SOURCE_ZIP@.sha1">@MODEL_SOURCE_ZIP_SHA1@</a></td>
                             </tr>
                             <tr>
                                 <td rowspan="2"><img src="images/square_c++.png"
@@ -376,6 +376,21 @@
                                 <td><a href="@FILES_SOURCE_ZIP@"><img src="images/square_zip.png" alt="zip"/></a></td>
                                 <td align="right">@FILES_SOURCE_ZIP_SIZE@</td>
                                 <td align="center"><a href="@FILES_SOURCE_ZIP@.sha1">@FILES_SOURCE_ZIP_SHA1@</a></td>
+                            </tr>
+                            <tr>
+                                <td rowspan="2"><img src="images/square_c++.png"
+                                                     alt="C++ source"/></td>
+                                <td rowspan="2">OME&nbsp;QtWidgets</td>
+                                <td rowspan="2"><a href="http://github.com/ome/ome-qtwidgets"><img src="images/square_github.png" alt="zip"/></a></td>
+                                <td rowspan="2"><a href="@QTWIDGETS_TAG_URL@">v@QTWIDGETS_VERSION@</a></td>
+                                <td><a href="@QTWIDGETS_SOURCE_TXZ@"><img src="images/square_txz.png" alt="txz"/></a></td>
+                                <td align="right">@QTWIDGETS_SOURCE_TXZ_SIZE@</td>
+                                <td align="center"><a href="@QTWIDGETS_SOURCE_TXZ@.sha1">@QTWIDGETS_SOURCE_TXZ_SHA1@</a></td>
+                            </tr>
+                            <tr>
+                                <td><a href="@QTWIDGETS_SOURCE_ZIP@"><img src="images/square_zip.png" alt="zip"/></a></td>
+                                <td align="right">@QTWIDGETS_SOURCE_ZIP_SIZE@</td>
+                                <td align="center"><a href="@QTWIDGETS_SOURCE_ZIP@.sha1">@QTWIDGETS_SOURCE_ZIP_SHA1@</a></td>
                             </tr>
                             <tr>
                                 <td rowspan="2"><img src="images/square_cmake.png"

--- a/files_cpp_downloads.html
+++ b/files_cpp_downloads.html
@@ -97,7 +97,7 @@
                             <tr>
                                 <td rowspan="2"><img src="images/square_centos.png"
                                                      alt="CentOS"/></td>
-                                <td rowspan="2">CentOS&nbsp;7.2</td>
+                                <td rowspan="2">CentOS&nbsp;7.3</td>
                                 <td>Release</td>
                                 <td><a href="@CENTOS72_RELEASE@"><img src="images/square_txz.png" alt="txz"/></a></td>
                                 <td align="right">@CENTOS72_RELEASE_SIZE@</td>

--- a/files_cpp_downloads.html
+++ b/files_cpp_downloads.html
@@ -350,7 +350,7 @@
                             <tr>
                                 <td rowspan="2"><img src="images/square_c++.png"
                                                      alt="C++ source"/></td>
-                                <td rowspan="2">OME&nbsp;XML</td>
+                                <td rowspan="2">OME&nbsp;Model</td>
                                 <td rowspan="2"><a href="http://github.com/ome/ome-model"><img src="images/square_github.png" alt="zip"/></a></td>
                                 <td rowspan="2"><a href="@MODEL_TAG_URL@">v@MODEL_VERSION@</a></td>
                                 <td><a href="@MODEL_SOURCE_TXZ@"><img src="images/square_txz.png" alt="txz"/></a></td>

--- a/files_cpp_downloads.html
+++ b/files_cpp_downloads.html
@@ -589,10 +589,9 @@
                 </div>
                 <h2><a name="previous" id="previous"></a>Previous versions</h2>
                     <p>
-                        Previous versions of OME Files C++ (formerly
-                        named "Bio-Formats C++") can be found on the
-                        <a href="http://downloads.openmicroscopy.org/bio-formats-cpp/?C=M;O=D"
-                           >Bio-Formats C++ archive</a> page.
+                        Previous versions of OME Files C++ can be found on the
+                        <a href="http://downloads.openmicroscopy.org/ome-files-cpp/?C=M;O=D"
+                           >OME Files C++ archive</a> page.
                     </p>
             </div><!-- /.entry-content -->
 

--- a/filescppgen.py
+++ b/filescppgen.py
@@ -41,10 +41,13 @@ repl["@SUPERBUILD_TAG_URL@"] = get_tag_url("ome-cmake-superbuild",
                                            org="ome")
 repl["@COMMON_TAG_URL@"] = get_tag_url("ome-common-cpp",
                                        common_version, org="ome")
-repl["@MODEL_TAG_URL@"] = get_tag_url("ome-model", model_version)
+repl["@MODEL_TAG_URL@"] = get_tag_url("ome-model", model_version,
+                                      org="ome")
 repl["@FILES_TAG_URL@"] = get_tag_url("ome-files-cpp",
                                       files_version, org="ome")
-repl["@QTWIDGETS_TAG_URL@"] = get_tag_url("ome-qtwidgets", qtwidgets_version)
+repl["@QTWIDGETS_TAG_URL@"] = get_tag_url("ome-qtwidgets",
+                                          qtwidgets_version,
+                                          org="ome")
 
 repl["@DOC_URL@"] = (
     "docs/ome-files-bundle-docs-%s-b%s/" %

--- a/filescppgen.py
+++ b/filescppgen.py
@@ -89,11 +89,11 @@ ome_sources = [
       "ome-common-cpp-%s.zip") % (
           common_version, common_version)),
     ("MODEL_SOURCE_TXZ", RELATIVE_PATH +
-     ("ome-model/%s/artifacts/" +
+     ("ome-model/%s/source/" +
       "ome-model-%s.tar.xz") % (
           model_version, model_version)),
     ("MODEL_SOURCE_ZIP", RELATIVE_PATH +
-     ("ome-model/%s/artifacts/" +
+     ("ome-model/%s/source/" +
       "ome-model-%s.zip") % (
           model_version, model_version)),
     ("FILES_SOURCE_TXZ", RELATIVE_PATH +

--- a/filescppgen.py
+++ b/filescppgen.py
@@ -16,25 +16,25 @@ def usage():
 
 
 try:
-    files_version = sys.argv[1]
-    buildid = sys.argv[2]
+    buildid = sys.argv[1]
 except:
     usage()
 
 # Read major and minor version from input version
 major_version, minor_version = get_version(files_version)
 
-superbuild_version = '0.2.4'
-common_version = '5.3.2'
-bf_version = '5.2.4'
-bf_major_version, bf_minor_version = get_version(bf_version)
+superbuild_version = '0.3.0'
+common_version = '5.4.0'
+model_version = '5.5.0'
+files_version = '0.3.0'
+qtwidgets_version = '5.4.0'
 
 repl = {"@VERSION@": files_version,
         "@BUILDID@": buildid,
-        "@BF_VERSION@": bf_version,
-        "@XML_VERSION@": bf_version,
+        "@MODEL_VERSION@": model_version,
         "@COMMON_VERSION@": common_version,
         "@FILES_VERSION@": files_version,
+        "@QTWIDGETS_VERSION@": qtwidgets_version,
         "@SUPERBUILD_VERSION@": superbuild_version,
         "@MONTHYEAR@": datetime.datetime.now().strftime("%b %Y"),
         "@YEAR@": datetime.datetime.now().strftime("%Y")}
@@ -44,9 +44,10 @@ repl["@SUPERBUILD_TAG_URL@"] = get_tag_url("ome-cmake-superbuild",
                                            org="ome")
 repl["@COMMON_TAG_URL@"] = get_tag_url("ome-common-cpp",
                                        common_version, org="ome")
-repl["@XML_TAG_URL@"] = get_tag_url("bioformats", bf_version)
+repl["@MODEL_TAG_URL@"] = get_tag_url("ome-model", model_version)
 repl["@FILES_TAG_URL@"] = get_tag_url("ome-files-cpp",
                                       files_version, org="ome")
+repl["@QTWIDGETS_TAG_URL@"] = get_tag_url("ome-qtwidgets", qtwidgets_version)
 
 repl["@DOC_URL@"] = (
     "docs/ome-files-bundle-docs-%s-b%s/" %
@@ -82,14 +83,14 @@ ome_sources = [
      ("ome-common-cpp/%s/source/" +
       "ome-common-cpp-%s.zip") % (
           common_version, common_version)),
-    ("BF_SOURCE_TXZ", RELATIVE_PATH +
-     ("bio-formats/%s/artifacts/" +
-      "bioformats-dfsg-%s.tar.xz") % (
-          bf_version, bf_version)),
-    ("BF_SOURCE_ZIP", RELATIVE_PATH +
-     ("bio-formats/%s/artifacts/" +
-      "bioformats-dfsg-%s.zip") % (
-          bf_version, bf_version)),
+    ("MODEL_SOURCE_TXZ", RELATIVE_PATH +
+     ("ome-model/%s/artifacts/" +
+      "ome-model-%s.tar.xz") % (
+          model_version, model_version)),
+    ("MODEL_SOURCE_ZIP", RELATIVE_PATH +
+     ("ome-model/%s/artifacts/" +
+      "ome-model-%s.zip") % (
+          model_version, model_version)),
     ("FILES_SOURCE_TXZ", RELATIVE_PATH +
      ("ome-files-cpp/%s/source/" +
       "ome-files-cpp-%s.tar.xz") % (
@@ -98,6 +99,14 @@ ome_sources = [
      ("ome-files-cpp/%s/source/" +
       "ome-files-cpp-%s.zip") % (
           files_version, files_version)),
+    ("QTWIDGETS_SOURCE_TXZ", RELATIVE_PATH +
+     ("ome-qtwidgets-cpp/%s/source/" +
+      "ome-qtwidgets-cpp-%s.tar.xz") % (
+          qtwidgets_version, qtwidgets_version)),
+    ("QTWIDGETS_SOURCE_ZIP", RELATIVE_PATH +
+     ("ome-qtwidgets-cpp/%s/source/" +
+      "ome-qtwidgets-cpp-%s.zip") % (
+          qtwidgets_version, qtwidgets_version)),
     ("SUPERBUILD_SOURCE_TXZ", RELATIVE_PATH +
      ("ome-cmake-superbuild/%s/source/" +
       "ome-cmake-superbuild-%s.tar.xz") % (
@@ -108,22 +117,18 @@ ome_sources = [
           superbuild_version, superbuild_version))]
 
 thirdparty_sources = {
-    'BOOST_SOURCE': 'boost_1_62_0.tar.bz2',
+    'BOOST_SOURCE': 'boost_1_63_0.tar.bz2',
     'BZIP2_SOURCE': 'bzip2-1.0.6.tar.gz',
     'GTEST_SOURCE': 'release-1.8.0.tar.gz',
     'ICU_SOURCE': 'icu4c-57_1-src.tgz',
-    'PNG_SOURCE': 'libpng-1.6.25.tar.xz',
+    'PNG_SOURCE': 'libpng-1.6.28.tar.xz',
     'TIFF_SOURCE': 'tiff-4.0.7.tar.gz',
-    'TP_BF_SOURCE': 'bioformats-dfsg-%s.tar.xz' % (bf_version),
-    'TP_COMMON_SOURCE': 'ome-common-cpp-%s.tar.xz' % (common_version),
-    'TP_FILES_SOURCE': 'ome-files-cpp-%s.tar.xz' % (files_version),
     'XALAN_SOURCE': 'xalan_c-1.11-src.tar.gz',
     'XERCES_SOURCE': 'xerces-c-3.1.4.tar.xz',
-    'ZLIB_SOURCE': 'zlib-1.2.8.tar.xz'}
+    'ZLIB_SOURCE': 'zlib-1.2.10.tar.xz'}
 
 thirdparty_tools = {
     'PATCH_SOURCE': 'patch-2.5.9-7-bin.zip',
-    'PY_DOCUTILS_SOURCE': 'docutils-0.12.tar.gz',
     'PY_GENSHI_SOURCE': 'Genshi-0.7.tar.gz',
     'PY_JINJA2_SOURCE': 'Jinja2-2.7.3.tar.gz',
     'PY_MARKUPSAFE_SOURCE': 'MarkupSafe-0.23.tar.gz',

--- a/filescppgen.py
+++ b/filescppgen.py
@@ -11,7 +11,7 @@ from doc_generator import find_pkg, repl_all
 
 
 def usage():
-    print "filescppgen.py version buildid"
+    print "filescppgen.py buildid"
     sys.exit(1)
 
 

--- a/filescppgen.py
+++ b/filescppgen.py
@@ -6,7 +6,7 @@ import sys
 import datetime
 import fileinput
 
-from utils import RSYNC_PATH, get_version, get_tag_url
+from utils import RSYNC_PATH, get_tag_url
 from doc_generator import find_pkg, repl_all
 
 

--- a/filescppgen.py
+++ b/filescppgen.py
@@ -147,7 +147,7 @@ platforms = {'UBUNTU1404': 'Ubuntu14.04-x86_64',
              'OSX1012':    'MacOSX10.12.1-x86_64',
              'FREEBSD11':  'FreeBSD11.0-amd64',
              'CENTOS68':   'CentOS6.8-x86_64',
-             'CENTOS72':   'CentOS7.2-x86_64'}
+             'CENTOS72':   'CentOS7.3-x86_64'}
 
 win_platforms = {'WINDOWSVC12X64': 'VC12-x64',
                  'WINDOWSVC12X86': 'VC12-x86',

--- a/filescppgen.py
+++ b/filescppgen.py
@@ -20,9 +20,6 @@ try:
 except:
     usage()
 
-# Read major and minor version from input version
-major_version, minor_version = get_version(files_version)
-
 superbuild_version = '0.3.0'
 common_version = '5.4.0'
 model_version = '5.5.0'

--- a/filescppgen.py
+++ b/filescppgen.py
@@ -105,12 +105,12 @@ ome_sources = [
       "ome-files-cpp-%s.zip") % (
           files_version, files_version)),
     ("QTWIDGETS_SOURCE_TXZ", RELATIVE_PATH +
-     ("ome-qtwidgets-cpp/%s/source/" +
-      "ome-qtwidgets-cpp-%s.tar.xz") % (
+     ("ome-qtwidgets/%s/source/" +
+      "ome-qtwidgets-%s.tar.xz") % (
           qtwidgets_version, qtwidgets_version)),
     ("QTWIDGETS_SOURCE_ZIP", RELATIVE_PATH +
-     ("ome-qtwidgets-cpp/%s/source/" +
-      "ome-qtwidgets-cpp-%s.zip") % (
+     ("ome-qtwidgets/%s/source/" +
+      "ome-qtwidgets-%s.zip") % (
           qtwidgets_version, qtwidgets_version)),
     ("SUPERBUILD_SOURCE_TXZ", RELATIVE_PATH +
      ("ome-cmake-superbuild/%s/source/" +

--- a/filescppgen.py
+++ b/filescppgen.py
@@ -11,12 +11,13 @@ from doc_generator import find_pkg, repl_all
 
 
 def usage():
-    print "filescppgen.py buildid"
+    print "filescppgen.py files_version buildid"
     sys.exit(1)
 
 
 try:
-    buildid = sys.argv[1]
+    files_job_version = sys.argv[1]
+    buildid = sys.argv[2]
 except:
     usage()
 
@@ -25,6 +26,10 @@ common_version = '5.4.0'
 model_version = '5.5.0'
 files_version = '0.3.0'
 qtwidgets_version = '5.4.0'
+
+if files_job_version != files_version:
+    print "files version mismatch"
+    sys.exit(1)
 
 repl = {"@VERSION@": files_version,
         "@BUILDID@": buildid,

--- a/filescppgen.py
+++ b/filescppgen.py
@@ -144,7 +144,7 @@ thirdparty_tools = {
 
 # Links to Bio-Formats C++ binaries
 platforms = {'UBUNTU1404': 'Ubuntu14.04-x86_64',
-             'OSX1012':    'MacOSX10.12.1-x86_64',
+             'OSX1012':    'MacOSX10.12.2-x86_64',
              'FREEBSD11':  'FreeBSD11.0-amd64',
              'CENTOS68':   'CentOS6.8-x86_64',
              'CENTOS72':   'CentOS7.3-x86_64'}


### PR DESCRIPTION
- Update versions
- Rename ome-xml/bioformats to model (except API ref)
- Add QtWidgets sources back (was disabled due to C++11 build failure)

Note that this drops the files version as a command-line argument.  The reason for this is that it's not possible to modify this in practice and so doesn't make sense to specify here.  It's specified by the superbuild, so can't be changed independently of any of the other versions.  In consequence, we should specify it in the script as for the other versions.  The build number is still specified as an argument.