### PR TITLE
missing icon

### DIFF
--- a/images/plonematch.css
+++ b/images/plonematch.css
@@ -450,8 +450,6 @@ blockquote {
     background-color: #000066;
     border-top: 14px solid #E6E7E8;
     border-bottom: 0px solid #B3B3E6;
-    background-image:  url(corner-cell.gif); 
-    layer-background-image: url(corner-cell.gif); 
     background-position: center right; 
     background-repeat: no-repeat;
 }


### PR DESCRIPTION
Noticed by @manics when inspecting the http://downloads.openmicroscopy.org/omero/5.3.0-m8/ page
The problem has been there for a long time
Remove ref to corner-gif since the image does not exist

To check 
open the page in chrome for example, click inspect

cc @hflynn 