### PR TITLE
Bump versions for OME Files C++ 0.3.2 release

### DIFF
--- a/filescppgen.py
+++ b/filescppgen.py
@@ -21,10 +21,10 @@ try:
 except:
     usage()
 
-superbuild_version = '0.3.1'
+superbuild_version = '0.3.2'
 common_version = '5.4.0'
 model_version = '5.5.1'
-files_version = '0.3.1'
+files_version = '0.3.2'
 qtwidgets_version = '5.4.0'
 
 if files_job_version != files_version:


### PR DESCRIPTION
Should be tested by the next run of https://ci.openmicroscopy.org/job/OME-FILES-CPP-DEV-release-downloads/